### PR TITLE
Add security backlog items for jobs and worker loader

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -26,6 +26,12 @@
 - [ ] Remove default Postgres credentials from `docker-compose.yml` (force overrides or prompt at deploy time).
 - [ ] Add automated tests covering malicious zip uploads, slug fuzzing, and toolkit activation edge cases.
 
+## Job Orchestration
+- [ ] Update `/jobs` listing to keep toolkit and module filters separate so module-only queries return the correct jobs.
+
+## Toolkit Worker Lifecycle
+- [ ] Ensure `load_toolkit_workers` only records a slug as loaded after the worker module registers successfully, allowing retries when registration fails.
+
 ## Follow-up Questions / Planning
 - [ ] Define the review/approval process for community-submitted toolkits before they reach production.
 - [ ] Evaluate containerized Vault deployment options (official Vault Docker image with persistent storage + TLS) and integrate into docker-compose or orchestration stack.


### PR DESCRIPTION
## Summary
- add a job orchestration backlog item to split toolkit and module filters in the jobs listing
- add a toolkit worker lifecycle backlog item to retry loading when registration fails

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68ce22d1358083288d31e7f347a53a8c