### PR TITLE
Fix module filtering for job listings

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -27,7 +27,7 @@
 - [ ] Add automated tests covering malicious zip uploads, slug fuzzing, and toolkit activation edge cases.
 
 ## Job Orchestration
-- [ ] Update `/jobs` listing to keep toolkit and module filters separate so module-only queries return the correct jobs.
+- [x] Update `/jobs` listing to keep toolkit and module filters separate so module-only queries return the correct jobs.
 
 ## Toolkit Worker Lifecycle
 - [ ] Ensure `load_toolkit_workers` only records a slug as loaded after the worker module registers successfully, allowing retries when registration fails.

--- a/backend/app/routes/jobs.py
+++ b/backend/app/routes/jobs.py
@@ -31,14 +31,7 @@ def list_jobs(
     toolkit: Optional[List[str]] = Query(default=None),
     module: Optional[List[str]] = Query(default=None),
 ):
-    combined = None
-    if toolkit or module:
-        combined = []
-        if toolkit:
-            combined.extend(toolkit)
-        if module:
-            combined.extend(module)
-    jobs = list_job_status(toolkits=combined)
+    jobs = list_job_status(toolkits=toolkit, modules=module)
     return {"jobs": jobs}
 
 

--- a/backend/app/worker_client.py
+++ b/backend/app/worker_client.py
@@ -23,8 +23,12 @@ def get_job_status(job_id: str) -> dict:
     return job
 
 
-def list_job_status(limit: Optional[int] = None, toolkits: Optional[Iterable[str]] = None) -> list[dict]:
-    return job_store.list_jobs(limit=limit, toolkits=toolkits)
+def list_job_status(
+    limit: Optional[int] = None,
+    toolkits: Optional[Iterable[str]] = None,
+    modules: Optional[Iterable[str]] = None,
+) -> list[dict]:
+    return job_store.list_jobs(limit=limit, toolkits=toolkits, modules=modules)
 
 
 def cancel_job(job_id: str) -> Optional[Dict[str, Any]]:

--- a/backend/tests/test_jobs_service.py
+++ b/backend/tests/test_jobs_service.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from typing import Iterable, List
+from unittest.mock import patch
+
+from app.services import jobs as job_service
+
+
+class FakeRedis:
+    def __init__(self, jobs: Iterable[dict]):
+        self._values = [job_service._dump(job) for job in jobs]
+
+    def hvals(self, key: str) -> List[str]:  # pragma: no cover - exercised via tests
+        return list(self._values)
+
+
+def _job(
+    *,
+    job_id: str,
+    toolkit: str,
+    module: str,
+    created_at: str,
+) -> dict:
+    return {
+        "id": job_id,
+        "toolkit": toolkit,
+        "module": module,
+        "operation": "test.run",
+        "type": f"{toolkit}.test.run",
+        "status": "queued",
+        "progress": 0,
+        "logs": [],
+        "created_at": created_at,
+        "updated_at": created_at,
+    }
+
+
+def test_list_jobs_filters_by_module_only():
+    jobs = [
+        _job(
+            job_id="job-alpha",
+            toolkit="alpha",
+            module="alpha.core",
+            created_at="2024-01-01T00:00:00+00:00",
+        ),
+        _job(
+            job_id="job-beta-utils",
+            toolkit="beta",
+            module="beta.utils",
+            created_at="2024-01-02T00:00:00+00:00",
+        ),
+        _job(
+            job_id="job-beta-gamma",
+            toolkit="beta",
+            module="gamma.special",
+            created_at="2024-01-03T00:00:00+00:00",
+        ),
+    ]
+
+    fake_redis = FakeRedis(jobs)
+    with patch("app.services.jobs.get_redis", return_value=fake_redis):
+        results = job_service.list_jobs(modules=["gamma.special"])
+
+    assert [job["id"] for job in results] == ["job-beta-gamma"]
+
+
+def test_list_jobs_applies_toolkit_and_module_filters_independently():
+    jobs = [
+        _job(
+            job_id="job-alpha",
+            toolkit="alpha",
+            module="alpha.core",
+            created_at="2024-01-01T00:00:00+00:00",
+        ),
+        _job(
+            job_id="job-beta-utils",
+            toolkit="beta",
+            module="beta.utils",
+            created_at="2024-01-02T00:00:00+00:00",
+        ),
+        _job(
+            job_id="job-beta-gamma",
+            toolkit="beta",
+            module="gamma.special",
+            created_at="2024-01-03T00:00:00+00:00",
+        ),
+    ]
+
+    fake_redis = FakeRedis(jobs)
+    with patch("app.services.jobs.get_redis", return_value=fake_redis):
+        results = job_service.list_jobs(toolkits=["beta"], modules=["beta.utils"])
+
+    assert [job["id"] for job in results] == ["job-beta-utils"]


### PR DESCRIPTION
## Summary
- keep toolkit and module filters separate across the jobs route and worker client
- ensure the jobs service applies independent toolkit and module filtering
- add coverage for module-only queries and mark the TODO as complete

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_b_68ce3104f9c483289cbf6be0f8d51ce7