### PR TITLE
Bug fix/hardening zip extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ These bundles mirror the format expected by the runtime, so you can use them as 
 2. **Backend module** – expose a FastAPI `APIRouter` (default attribute `router`) that is mounted under `/toolkits/<slug>`.
 3. **Worker module** – export a callable (default `register`) to register Celery tasks like `<slug>.<operation>`. The runtime injects the shared Celery app and a `register_handler` helper when requested.
 4. **Frontend bundle (optional)** – ship an ESM entry at `frontend/dist/index.js`. During development, toolkits can point to `frontend/index.tsx` so Vite provides hot reloads. At runtime the App Shell injects `React`, `React Router`, and `apiFetch` through `window.__SRE_TOOLKIT_RUNTIME`.
-5. **Package** – run `python toolkits/scripts/package_toolkit.py <path>` to validate the manifest and emit `<slug>_toolkit.zip`. Upload the archive from Admin → Toolkits or via `POST /toolkits/install`. The installer unpacks bundles into `TOOLKIT_STORAGE_DIR/<slug>/` and serves static assets from `/toolkit-assets/<slug>/…`.
+5. **Package** – run `python toolkits/scripts/package_toolkit.py <path>` to validate the manifest and emit `<slug>_toolkit.zip`. Upload the archive from Admin → Toolkits or via `POST /toolkits/install`. The installer rejects archives containing absolute paths, drive letters, parent-directory segments, or symlinks and, once validated, unpacks bundles into `TOOLKIT_STORAGE_DIR/<slug>/` while serving static assets from `/toolkit-assets/<slug>/…`.
 
 Example manifest:
 

--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,7 @@
 ## Toolkit Upload & Execution
 - [ ] Harden zip extraction in `backend/app/routes/toolkits.py` and `backend/app/toolkits/install_utils.py`:
   - [x] Reject absolute/parent-path entries and symlinks during FastAPI upload handling.
-  - [ ] Stream uploads to disk and enforce per-file/total size limits to block zip bombs.
+  - [x] Stream uploads to disk and enforce per-file/total size limits to block zip bombs.
   - [ ] Copy artefacts with traversal-safe APIs (e.g. `copytree(..., dirs_exist_ok=True)` after validation).
 - [ ] Validate toolkit slugs everywhere (manifest parsing, API input, CLI packagers) against a strict allowlist before using them in file paths or imports.
 - [ ] Normalize uploaded filenames before persisting (strip directories, randomise collisions).

--- a/TODO.md
+++ b/TODO.md
@@ -2,9 +2,9 @@
 
 ## Toolkit Upload & Execution
 - [ ] Harden zip extraction in `backend/app/routes/toolkits.py` and `backend/app/toolkits/install_utils.py`:
-  - Reject absolute/parent-path entries, symlinks, and dangerous filenames.
-  - Stream uploads to disk and enforce per-file/total size limits to block zip bombs.
-  - Copy artefacts with traversal-safe APIs (e.g. `copytree(..., dirs_exist_ok=True)` after validation).
+  - [x] Reject absolute/parent-path entries and symlinks during FastAPI upload handling.
+  - [ ] Stream uploads to disk and enforce per-file/total size limits to block zip bombs.
+  - [ ] Copy artefacts with traversal-safe APIs (e.g. `copytree(..., dirs_exist_ok=True)` after validation).
 - [ ] Validate toolkit slugs everywhere (manifest parsing, API input, CLI packagers) against a strict allowlist before using them in file paths or imports.
 - [ ] Normalize uploaded filenames before persisting (strip directories, randomise collisions).
 - [ ] Remove the resolved `bundle_path` from API responses to avoid leaking server layout.
@@ -24,7 +24,8 @@
 ## Infrastructure & Tooling
 - [ ] Tighten `frontend/vite.config.ts` dev-server `fs.allow` list to the bare minimum.
 - [ ] Remove default Postgres credentials from `docker-compose.yml` (force overrides or prompt at deploy time).
-- [ ] Add automated tests covering malicious zip uploads, slug fuzzing, and toolkit activation edge cases.
+- [ ] Add automated tests covering slug fuzzing and toolkit activation edge cases.
+- [x] Add automated test to reject malicious zip uploads during toolkit installation.
 
 ## Job Orchestration
 - [x] Update `/jobs` listing to keep toolkit and module filters separate so module-only queries return the correct jobs.

--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,10 @@
 # Security Hardening TODO
 
 ## Toolkit Upload & Execution
-- [ ] Harden zip extraction in `backend/app/routes/toolkits.py` and `backend/app/toolkits/install_utils.py`:
+- [x] Harden zip extraction in `backend/app/routes/toolkits.py` and `backend/app/toolkits/install_utils.py`:
   - [x] Reject absolute/parent-path entries and symlinks during FastAPI upload handling.
   - [x] Stream uploads to disk and enforce per-file/total size limits to block zip bombs.
-  - [ ] Copy artefacts with traversal-safe APIs (e.g. `copytree(..., dirs_exist_ok=True)` after validation).
+  - [x] Copy artefacts with traversal-safe APIs (e.g. `copytree(..., dirs_exist_ok=True)` after validation).
 - [ ] Validate toolkit slugs everywhere (manifest parsing, API input, CLI packagers) against a strict allowlist before using them in file paths or imports.
 - [ ] Normalize uploaded filenames before persisting (strip directories, randomise collisions).
 - [ ] Remove the resolved `bundle_path` from API responses to avoid leaking server layout.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -103,6 +103,9 @@ class Settings(BaseSettings):
     frontend_base_url: AnyHttpUrl | None = Field(default=None)
     cors_origins: List[str] = Field(default_factory=default_cors_origins)
     toolkit_storage_dir: Path = Field(default=Path("./data/toolkits"))
+    toolkit_upload_max_bytes: int = Field(default=50 * 1024 * 1024)
+    toolkit_bundle_max_bytes: int = Field(default=200 * 1024 * 1024)
+    toolkit_bundle_max_file_bytes: int = Field(default=100 * 1024 * 1024)
     database_url: str = Field(default="sqlite+aiosqlite:///./data/app.db")
 
     auth_jwt_secret: SecretStr = Field(default=SecretStr("change-me"), repr=False)

--- a/backend/app/routes/toolkits.py
+++ b/backend/app/routes/toolkits.py
@@ -118,12 +118,6 @@ def toolkits_get(slug: str):
     return _get_toolkit_or_404(slug)
 
 
-@router.post(
-    "/install",
-    status_code=status.HTTP_202_ACCEPTED,
-    summary="Upload and register a toolkit bundle",
-    dependencies=[Depends(require_superuser)],
-)
 def _resolve_safe_member_path(
     member: zipfile.ZipInfo, destination_root: Path, destination_root_resolved: Path
 ) -> Path:
@@ -161,6 +155,12 @@ def _resolve_safe_member_path(
     return candidate_resolved
 
 
+@router.post(
+    "/install",
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Upload and register a toolkit bundle",
+    dependencies=[Depends(require_superuser)],
+)
 async def toolkits_install(slug: str | None = Form(None), file: UploadFile = File(...)):
     if slug and any(ch not in "abcdefghijklmnopqrstuvwxyz0123456789-_" for ch in slug.lower()):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Slug must contain only letters, numbers, hyphen, or underscore")

--- a/backend/tests/test_toolkits_install.py
+++ b/backend/tests/test_toolkits_install.py
@@ -1,0 +1,40 @@
+import io
+import zipfile
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException, UploadFile
+
+from app.routes import toolkits
+
+
+@pytest.mark.asyncio
+async def test_toolkits_install_rejects_path_traversal(tmp_path, monkeypatch):
+    storage_dir = tmp_path / "storage"
+    storage_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(toolkits.settings, "toolkit_storage_dir", storage_dir)
+
+    install_mock = MagicMock(side_effect=AssertionError("install_toolkit_from_directory should not run"))
+    monkeypatch.setattr(toolkits, "install_toolkit_from_directory", install_mock)
+
+    malicious_zip = io.BytesIO()
+    with zipfile.ZipFile(malicious_zip, "w") as zf:
+        zf.writestr("../../outside.txt", "pwned")
+    malicious_zip.seek(0)
+
+    upload = UploadFile(filename="malicious.zip", file=io.BytesIO(malicious_zip.getvalue()))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await toolkits.toolkits_install(slug="evil", file=upload)
+
+    assert exc_info.value.status_code == 400
+    install_mock.assert_not_called()
+
+    outside_path = storage_dir / "outside.txt"
+    assert not outside_path.exists()
+
+    bundle_path = storage_dir / "malicious.zip"
+    assert not bundle_path.exists()
+
+    toolkit_root = storage_dir / "__uploads__" / "evil"
+    assert not toolkit_root.exists()

--- a/backend/tests/test_toolkits_install_utils.py
+++ b/backend/tests/test_toolkits_install_utils.py
@@ -1,0 +1,87 @@
+import json
+import os
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.toolkits import install_utils
+from app.toolkits.install_utils import ToolkitManifestError, _validate_toolkit_tree, install_toolkit_from_directory
+
+
+def _write_manifest(path: Path, **overrides: str) -> None:
+    manifest = {
+        "slug": overrides.get("slug", "demo"),
+        "name": overrides.get("name", "Demo Toolkit"),
+        "description": overrides.get("description", ""),
+        "base_path": overrides.get("base_path", "/toolkits/demo"),
+    }
+    path.write_text(json.dumps(manifest))
+
+
+def test_validate_toolkit_tree_rejects_symlink(tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+
+    nested_dir = bundle / "nested"
+    nested_dir.mkdir()
+    (nested_dir / "file.txt").write_text("hello")
+    (bundle / "toolkit.json").write_text("{}")
+
+    malicious_link = bundle / "link"
+    malicious_link.symlink_to(nested_dir / "file.txt")
+
+    with pytest.raises(ToolkitManifestError) as exc_info:
+        _validate_toolkit_tree(bundle)
+
+    assert "symbolic links" in str(exc_info.value)
+
+
+def test_validate_toolkit_tree_rejects_root_symlink(tmp_path: Path) -> None:
+    real_root = tmp_path / "real"
+    real_root.mkdir()
+    (real_root / "toolkit.json").write_text("{}")
+
+    symlink_root = tmp_path / "alias"
+    symlink_root.symlink_to(real_root, target_is_directory=True)
+
+    with pytest.raises(ToolkitManifestError) as exc_info:
+        _validate_toolkit_tree(symlink_root)
+
+    assert "root may not be a symbolic link" in str(exc_info.value)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Named pipes are not supported on Windows")
+def test_validate_toolkit_tree_rejects_special_files(tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    (bundle / "toolkit.json").write_text("{}")
+
+    fifo_path = bundle / "fifo"
+    os.mkfifo(fifo_path)
+
+    with pytest.raises(ToolkitManifestError) as exc_info:
+        _validate_toolkit_tree(bundle)
+
+    assert "unsupported file type" in str(exc_info.value)
+
+
+def test_install_toolkit_rejects_destination_escape(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    storage_dir = tmp_path / "storage"
+    monkeypatch.setattr(install_utils.settings, "toolkit_storage_dir", storage_dir)
+
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    _write_manifest(bundle / "toolkit.json", slug="../escape")
+
+    sentinel = MagicMock(side_effect=AssertionError("should not be invoked"))
+    monkeypatch.setattr(install_utils, "clear_toolkit_removal", sentinel)
+    monkeypatch.setattr(install_utils, "create_toolkit", sentinel)
+    monkeypatch.setattr(install_utils, "update_toolkit", sentinel)
+    monkeypatch.setattr(install_utils, "activate_toolkit", sentinel)
+    monkeypatch.setattr(install_utils, "mark_toolkit_removed", sentinel)
+
+    with pytest.raises(ToolkitManifestError) as exc_info:
+        install_toolkit_from_directory(bundle)
+
+    assert "storage directory" in str(exc_info.value)

--- a/docs/project-setup.md
+++ b/docs/project-setup.md
@@ -35,3 +35,4 @@ Follow this guide when cloning the repo or preparing a new development environme
 ## Toolkit Storage
 - Bundled toolkits install on first boot under `TOOLKIT_STORAGE_DIR` (defaults to `./data/toolkits`).
 - Upload additional bundles from Admin → Toolkits or via `POST /toolkits/install`.
+- Toolkit uploads are capped by `TOOLKIT_UPLOAD_MAX_BYTES` (compressed size) and unpacking safeguards `TOOLKIT_BUNDLE_MAX_BYTES` / `TOOLKIT_BUNDLE_MAX_FILE_BYTES` to block zip bombs; tweak these in `.env` when needed.

--- a/docs/toolkit-authoring/testing-and-release.md
+++ b/docs/toolkit-authoring/testing-and-release.md
@@ -18,6 +18,7 @@ Follow this sequence before publishing a toolkit bundle so operators receive a r
 - Run `python toolkits/scripts/package_toolkit.py <path>` to build `<slug>_toolkit.zip`.
 - Include the generated archive and release notes in your artifact store (GitHub Releases, internal registry, etc.).
 - Bump the toolkit version in `toolkit.json` and include a changelog entry summarising major changes and migration steps.
+- Ensure the archive does not contain absolute paths, drive letters, parent-directory segments, or symlinks—uploads are rejected when these appear to prevent directory traversal during install.
 
 ## Rollback Strategy
 - Keep the previous release bundle available so operators can reinstall quickly if issues arise.

--- a/docs/toolkit-authoring/testing-and-release.md
+++ b/docs/toolkit-authoring/testing-and-release.md
@@ -19,6 +19,7 @@ Follow this sequence before publishing a toolkit bundle so operators receive a r
 - Include the generated archive and release notes in your artifact store (GitHub Releases, internal registry, etc.).
 - Bump the toolkit version in `toolkit.json` and include a changelog entry summarising major changes and migration steps.
 - Ensure the archive does not contain absolute paths, drive letters, parent-directory segments, or symlinks—uploads are rejected when these appear to prevent directory traversal during install.
+- Keep the archive within the enforced limits (`TOOLKIT_UPLOAD_MAX_BYTES` compressed, `TOOLKIT_BUNDLE_MAX_BYTES` total extracted, `TOOLKIT_BUNDLE_MAX_FILE_BYTES` per file) so installs cannot inflate into zip bombs.
 
 ## Rollback Strategy
 - Keep the previous release bundle available so operators can reinstall quickly if issues arise.


### PR DESCRIPTION
- [x] Harden zip extraction in `backend/app/routes/toolkits.py` and `backend/app/toolkits/install_utils.py`:
  - [x] Reject absolute/parent-path entries and symlinks during FastAPI upload handling.
  - [x] Stream uploads to disk and enforce per-file/total size limits to block zip bombs.
  - [x] Copy artefacts with traversal-safe APIs (e.g. `copytree(..., dirs_exist_ok=True)` after validation).