### PR TITLE
Restrict Vite dev server filesystem allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ npm install
 npm run dev -- --host 0.0.0.0 --port 5173
 ```
 
+The Vite dev server only allows files from `frontend/` and checked-in bundled toolkits (`toolkits/bundled`) to be served. When
+iterating on a bundled toolkit locally, keep its source within that directory so hot module reloading continues to work without
+exposing additional host paths.
+
 ## Configuration
 
 Core settings are read from environment variables (see `.env.example`). The table below highlights the most common knobs.

--- a/TODO.md
+++ b/TODO.md
@@ -22,7 +22,7 @@
 - [ ] Document secret provisioning workflow for operators (Vault policies, rotations, bootstrap tokens).
 
 ## Infrastructure & Tooling
-- [ ] Tighten `frontend/vite.config.ts` dev-server `fs.allow` list to the bare minimum.
+- [x] Tighten `frontend/vite.config.ts` dev-server `fs.allow` list to the bare minimum.
 - [ ] Remove default Postgres credentials from `docker-compose.yml` (force overrides or prompt at deploy time).
 - [ ] Add automated tests covering slug fuzzing and toolkit activation edge cases.
 - [x] Add automated test to reject malicious zip uploads during toolkit installation.

--- a/docs/project-setup.md
+++ b/docs/project-setup.md
@@ -25,6 +25,9 @@ Follow this guide when cloning the repo or preparing a new development environme
 2. `npm install`
 3. `npm run dev -- --host 0.0.0.0 --port 5173`
 
+> **Security note**: The Vite dev server only whitelists `frontend/` and bundled toolkit sources under `toolkits/bundled/`. Keep
+> toolkit code you want hot reloaded inside that directory so you don't need to broaden the filesystem allowlist.
+
 ## Docker Compose (all services)
 1. Copy `.env.example` to `.env` and adjust values.
 2. Run `docker compose up --build` from the repo root.

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,15 +5,14 @@ import { dirname, resolve } from 'node:path'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const projectRoot = resolve(__dirname, '.')
-const toolkitsDir = resolve(__dirname, '../toolkits')
-const storageDir = resolve(__dirname, '../data/toolkits')
+const bundledToolkitsDir = resolve(__dirname, '../toolkits/bundled')
 
 export default defineConfig({
   plugins: [react()],
   server: {
     port: 5173,
     fs: {
-      allow: [projectRoot, toolkitsDir, storageDir],
+      allow: [projectRoot, bundledToolkitsDir],
     },
   },
   resolve: {


### PR DESCRIPTION
## Summary
- limit the Vite dev server filesystem allowlist to the project root and bundled toolkit directory only
- document the tightened allowlist in the README and project setup guide
- check off the security TODO for the Vite fs.allow tightening

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68ce3de00fd883288ff0ca203635980a