### PR TITLE
Improve authentication and toolkit admin documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,14 @@ Core settings are read from environment variables (see `.env.example`). The tabl
 | `DATABASE_URL` | SQLAlchemy async database URL | `sqlite+aiosqlite:///./data/app.db` |
 | `REDIS_URL` / `REDIS_PREFIX` | Redis connection string and key prefix | `redis://redis:6379/0`, `sretoolbox` |
 | `TOOLKIT_STORAGE_DIR` | Filesystem directory for toolkit bundles | `./data/toolkits` |
+| `TOOLKIT_UPLOAD_MAX_BYTES` / `TOOLKIT_BUNDLE_MAX_BYTES` / `TOOLKIT_BUNDLE_MAX_FILE_BYTES` | Upload and extraction safeguards that block oversized bundles | `52428800` / `209715200` / `104857600` |
 | `FRONTEND_BASE_URL` | UI origin (no trailing slash) for automatic CORS configuration | `http://localhost:5173` |
 | `VITE_API_BASE_URL` | Frontend discovery of the API endpoint | `http://localhost:8080` |
-| `AUTH_JWT_SECRET`, `AUTH_JWT_ALGORITHM` | JWT signing secret/key algorithm | `change-me`, `HS256` |
+| `AUTH_JWT_SECRET` / `AUTH_JWT_PUBLIC_KEY` / `AUTH_JWT_PRIVATE_KEY` / `AUTH_JWT_ALGORITHM` | Signing secret or key pair and algorithm for access tokens | `change-me`, unset, unset, `HS256` |
+| `AUTH_ACCESS_TOKEN_TTL_SECONDS` / `AUTH_REFRESH_TOKEN_TTL_SECONDS` | Token lifetimes for access and refresh tokens | `900` / `1209600` |
 | `AUTH_COOKIE_SECURE`, `AUTH_COOKIE_SAMESITE`, `AUTH_COOKIE_DOMAIN` | Refresh-token cookie attributes | `true`, `lax`, unset |
+| `AUTH_PROVIDERS_JSON` / `AUTH_PROVIDERS_FILE` | Bootstrap SSO providers via JSON payload or file path | unset |
+| `AUTH_SSO_STATE_TTL_SECONDS` | Lifetime for signed SSO state/nonce records | `600` |
 | `BOOTSTRAP_ADMIN_*` | Optional seed admin account (username, password, email) | unset |
 
 Additional provider-specific settings (OIDC, LDAP/AD) can be injected via `AUTH_PROVIDERS_JSON` or added at runtime through the Admin → Auth settings screen.
@@ -129,6 +133,13 @@ Additional provider-specific settings (OIDC, LDAP/AD) can be injected via `AUTH_
 - **Administration → Toolkits** – upload `.zip` bundles, toggle visibility, uninstall toolkits, and inspect metadata derived from `toolkit.json`.
 - **Administration → Users** – invite local users, assign roles, or import external identities.
 - **Administration → Auth settings** – configure local, OIDC, LDAP, or Active Directory providers without redeploying.
+
+## Authentication & role-based access control
+
+- **Roles** – every account receives `toolkit.user` for day-to-day operations. Grant `toolkit.curator` to manage toolkit enablement and `system.admin` for security-sensitive settings (auth providers, user management, audit exports). All FastAPI routes and in-app controls honor these roles.
+- **Providers** – configure local username/password auth or plug in OpenID Connect, LDAP, and Active Directory providers. Define providers inline via `AUTH_PROVIDERS_JSON`, point at a JSON file with `AUTH_PROVIDERS_FILE`, or manage them at runtime from **Administration → Auth settings**. Changes reload instantly—no restart required.
+- **Session hygiene** – access tokens default to 15 minutes, refresh tokens to 14 days, and the API rotates refresh-token IDs on each renewal while persisting session metadata for revocation and auditing. Set `AUTH_COOKIE_SECURE`, `AUTH_COOKIE_SAMESITE`, and `AUTH_COOKIE_DOMAIN` to harden browser usage.
+- **SSO state** – requests are protected by signed state/nonce values with a configurable TTL (`AUTH_SSO_STATE_TTL_SECONDS`); pair this with HTTPS so cookies stay protected in transit.
 
 ## Bundled toolkits
 

--- a/frontend/documentation/toolbox-administration.md
+++ b/frontend/documentation/toolbox-administration.md
@@ -2,6 +2,12 @@
 
 Administrators manage toolkit lifecycles directly from the SRE Toolbox shell. This guide covers the high-level workflow and common tasks you can automate.
 
+## Role prerequisites
+
+- **Toolkit curators** (`toolkit.curator`) can enable, disable, and configure toolkits once they have been uploaded.
+- **System administrators** (`system.admin`) inherit curator privileges and can also install or remove bundles and manage authentication providers.
+- Standard operators (`toolkit.user`) can browse documentation and run jobs but cannot alter toolkit state.
+
 ## Enabling and Disabling Toolkits
 
 1. Navigate to **Administration → Toolkits**.
@@ -17,13 +23,21 @@ Administrators manage toolkit lifecycles directly from the SRE Toolbox shell. Th
 4. Submit the form—uploads are asynchronously extracted and registered.
 5. Enable the toolkit once validation passes.
 
+Uploads are validated defensively:
+
+- Bundles that contain absolute paths, parent-directory traversals, or symlinks are rejected before extraction.
+- Compressed uploads larger than `TOOLKIT_UPLOAD_MAX_BYTES` fail fast.
+- Extracted contents are capped by `TOOLKIT_BUNDLE_MAX_BYTES` overall and `TOOLKIT_BUNDLE_MAX_FILE_BYTES` per file to block zip bombs.
+
+Adjust those limits in `.env` when distributing unusually large toolkits.
+
 The REST API mirrors the UI form so you can script installations:
 
 ```bash
 curl -X POST \
   -F slug=my-toolkit \
   -F file=@toolkit.zip \
-  http://localhost:8000/toolkits/install
+  http://localhost:8080/toolkits/install
 ```
 
 ## Updating an Existing Toolkit
@@ -31,15 +45,17 @@ curl -X POST \
 - Upload a new bundle with the same slug. The Toolbox runtime swaps assets atomically and bumps the version timestamp.
 - Use `toolkit.json`’s `frontend_entry` or `frontend_source_entry` to point to fresh UI builds.
 - The runtime invalidates cached toolkit modules when metadata timestamps change.
+- Upload actions require `system.admin` so you can restrict bundle ingress to trusted operators.
 
 ## Removing a Toolkit
 
 1. Disable the toolkit to ensure no new jobs are scheduled.
 2. Click **Uninstall** on the toolkit card. Only uploaded (non-built-in) toolkits expose this action.
 3. The API and UI both delete the bundle payload and registry entry.
+4. Toolkit payloads live under `TOOLKIT_STORAGE_DIR/<slug>/`. Deleting a bundle removes that directory; if you need to reclaim disk space manually, target this path.
 
 ```bash
-curl -X DELETE http://localhost:8000/toolkits/my-toolkit
+curl -X DELETE http://localhost:8080/toolkits/my-toolkit
 ```
 
 ## Automating Administration
@@ -47,5 +63,6 @@ curl -X DELETE http://localhost:8000/toolkits/my-toolkit
 - Use the `/toolkits` REST endpoints to integrate with CI/CD pipelines.
 - Schedule periodic audits with the [Toolbox Job Monitoring](toolbox-job-monitoring) guidance to ensure idle toolkits can be toggled off.
 - Keep documentation in sync by linking to the relevant toolkit entry under [Toolkit Overview](toolkit).
+- Export toolkit metadata with `GET /toolkits` to build inventory reports or cross-check versions in change-management tooling.
 
 Continue with [Toolbox Job Monitoring](toolbox-job-monitoring) to understand how worker activity is surfaced to operators.


### PR DESCRIPTION
## Summary
- expand the configuration reference in the root README with token, SSO, and toolkit upload settings
- document RBAC expectations, provider management options, and session behaviour for operators
- update the in-app administration guides with role prerequisites, security limits, and correct API endpoints

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_b_68ce463063748328bdbb02e808427561