### PR TITLE
Add latency-sleuth optional toolkit

### DIFF
--- a/toolkits/latency_sleuth/BUILDING.md
+++ b/toolkits/latency_sleuth/BUILDING.md
@@ -1,0 +1,15 @@
+# Building the Latency Sleuth Toolkit
+
+Latency Sleuth ships as an optional toolkit bundle. Use the provided helper script to verify the manifest and produce a distributable archive.
+
+```bash
+python toolkits/scripts/package_toolkit.py toolkits/latency_sleuth
+```
+
+The command emits `latency-sleuth_toolkit.zip` alongside the source directory. Upload that archive through **Admin → Toolkits** in the Toolbox UI whenever you want to distribute a release candidate.
+
+## Release Checklist
+- Update `toolkit.json` with a bumped `version` and `updated_at` timestamp.
+- Regenerate operator documentation after any SLA tuning or alerting workflow changes.
+- Run backend (`pytest`), worker, and frontend (`vitest`) tests from this directory before packaging.
+- Capture noteworthy changes in your release notes so operators understand behavioural differences.

--- a/toolkits/latency_sleuth/backend/__init__.py
+++ b/toolkits/latency_sleuth/backend/__init__.py
@@ -1,0 +1,3 @@
+from .app import router
+
+__all__ = ["router"]

--- a/toolkits/latency_sleuth/backend/app.py
+++ b/toolkits/latency_sleuth/backend/app.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from typing import List, Optional
+
+from fastapi import APIRouter, HTTPException, Response, status
+from pydantic import BaseModel, Field
+
+from app.services import jobs as job_store
+from app.worker_client import enqueue_job
+
+from .models import (
+    LatencyHeatmap,
+    ProbeExecutionSummary,
+    ProbeTemplate,
+    ProbeTemplateCreate,
+    ProbeTemplateUpdate,
+)
+from .probes import execute_probe
+from .storage import (
+    build_heatmap,
+    create_template,
+    delete_template,
+    get_template,
+    list_history,
+    list_templates,
+    update_template,
+)
+
+
+router = APIRouter()
+
+
+class ProbeRunRequest(BaseModel):
+    sample_size: int = Field(default=3, ge=1, le=20)
+    latency_overrides: Optional[List[float]] = None
+
+
+@router.get("/probe-templates", response_model=List[ProbeTemplate])
+def probe_templates_index() -> List[ProbeTemplate]:
+    return sorted(list_templates(), key=lambda template: template.created_at)
+
+
+@router.post(
+    "/probe-templates",
+    response_model=ProbeTemplate,
+    status_code=status.HTTP_201_CREATED,
+)
+def probe_templates_create(payload: ProbeTemplateCreate) -> ProbeTemplate:
+    return create_template(payload)
+
+
+@router.get("/probe-templates/{template_id}", response_model=ProbeTemplate)
+def probe_templates_show(template_id: str) -> ProbeTemplate:
+    template = get_template(template_id)
+    if not template:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Template not found")
+    return template
+
+
+@router.put("/probe-templates/{template_id}", response_model=ProbeTemplate)
+def probe_templates_update(template_id: str, payload: ProbeTemplateUpdate) -> ProbeTemplate:
+    template = update_template(template_id, payload)
+    if not template:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Template not found")
+    return template
+
+
+@router.delete("/probe-templates/{template_id}", status_code=status.HTTP_204_NO_CONTENT)
+def probe_templates_delete(template_id: str) -> Response:
+    deleted = delete_template(template_id)
+    if not deleted:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Template not found")
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.post(
+    "/probe-templates/{template_id}/actions/preview",
+    response_model=ProbeExecutionSummary,
+)
+def probe_templates_preview(template_id: str, payload: ProbeRunRequest | None = None) -> ProbeExecutionSummary:
+    template = get_template(template_id)
+    if not template:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Template not found")
+    params = payload or ProbeRunRequest()
+    return execute_probe(
+        template,
+        sample_size=params.sample_size,
+        overrides=params.latency_overrides,
+    )
+
+
+@router.post(
+    "/probe-templates/{template_id}/actions/run",
+    status_code=status.HTTP_202_ACCEPTED,
+)
+def probe_templates_run(template_id: str, payload: ProbeRunRequest | None = None) -> dict:
+    template = get_template(template_id)
+    if not template:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Template not found")
+    params = payload or ProbeRunRequest()
+    job = enqueue_job(
+        toolkit="latency-sleuth",
+        operation="run_probe",
+        payload={
+            "template_id": template_id,
+            "sample_size": params.sample_size,
+            "latency_overrides": params.latency_overrides,
+        },
+    )
+    return {"job": job}
+
+
+@router.get("/probe-templates/{template_id}/heatmap", response_model=LatencyHeatmap)
+def probe_templates_heatmap(template_id: str, columns: int = 6) -> LatencyHeatmap:
+    template = get_template(template_id)
+    if not template:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Template not found")
+    return build_heatmap(template_id, columns=columns)
+
+
+@router.get("/probe-templates/{template_id}/history", response_model=List[ProbeExecutionSummary])
+def probe_templates_history(template_id: str, limit: int = 10) -> List[ProbeExecutionSummary]:
+    template = get_template(template_id)
+    if not template:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Template not found")
+    history = list_history(template_id, limit=limit)
+    return [entry.summary for entry in history]
+
+
+@router.get("/jobs")
+def list_jobs(template_id: Optional[str] = None) -> List[dict]:
+    jobs = job_store.list_jobs(toolkits=["latency-sleuth"])
+    if template_id:
+        jobs = [job for job in jobs if job.get("payload", {}).get("template_id") == template_id]
+    return jobs
+
+
+@router.get("/jobs/{job_id}")
+def get_job(job_id: str) -> dict:
+    job = job_store.get_job(job_id)
+    if not job:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
+    return job

--- a/toolkits/latency_sleuth/backend/models.py
+++ b/toolkits/latency_sleuth/backend/models.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from statistics import mean
+from typing import List, Literal, Optional
+
+from pydantic import BaseModel, Field, HttpUrl, field_validator
+
+
+NotificationChannel = Literal["slack", "pagerduty", "email", "webhook"]
+NotificationThreshold = Literal["always", "breach", "recovery"]
+
+
+class NotificationRule(BaseModel):
+    """Describe how probe breaches should alert external systems."""
+
+    channel: NotificationChannel
+    target: str = Field(..., min_length=1)
+    threshold: NotificationThreshold = "breach"
+
+
+class ProbeTemplateBase(BaseModel):
+    """Common payload shared across template operations."""
+
+    name: str = Field(..., min_length=1, max_length=120)
+    description: Optional[str] = Field(default=None, max_length=500)
+    url: HttpUrl
+    method: Literal["GET", "HEAD", "POST"] = "GET"
+    sla_ms: int = Field(..., gt=0, le=60000)
+    interval_seconds: int = Field(default=300, ge=30, le=3600)
+    notification_rules: List[NotificationRule] = Field(default_factory=list)
+    tags: List[str] = Field(default_factory=list)
+
+    @field_validator("tags")
+    @classmethod
+    def _dedupe_tags(cls, value: List[str]) -> List[str]:
+        seen = []
+        for tag in value:
+            if tag and tag not in seen:
+                seen.append(tag)
+        return seen
+
+
+class ProbeTemplateCreate(ProbeTemplateBase):
+    pass
+
+
+class ProbeTemplateUpdate(BaseModel):
+    name: Optional[str] = Field(default=None, min_length=1, max_length=120)
+    description: Optional[str] = Field(default=None, max_length=500)
+    url: Optional[HttpUrl] = None
+    method: Optional[Literal["GET", "HEAD", "POST"]] = None
+    sla_ms: Optional[int] = Field(default=None, gt=0, le=60000)
+    interval_seconds: Optional[int] = Field(default=None, ge=30, le=3600)
+    notification_rules: Optional[List[NotificationRule]] = None
+    tags: Optional[List[str]] = None
+
+    @field_validator("tags")
+    @classmethod
+    def _dedupe_tags(cls, value: Optional[List[str]]) -> Optional[List[str]]:
+        if value is None:
+            return value
+        seen: List[str] = []
+        for tag in value:
+            if tag and tag not in seen:
+                seen.append(tag)
+        return seen
+
+
+class ProbeTemplate(ProbeTemplateBase):
+    id: str
+    created_at: datetime
+    updated_at: datetime
+
+
+class ProbeExecutionSample(BaseModel):
+    attempt: int
+    timestamp: datetime
+    latency_ms: float
+    breach: bool
+    message: Optional[str] = None
+
+
+class ProbeExecutionSummary(BaseModel):
+    template_id: str
+    template_name: str
+    sla_ms: int
+    samples: List[ProbeExecutionSample]
+    average_latency_ms: float
+    breach_count: int
+    met_sla: bool
+    notified_channels: List[NotificationChannel] = Field(default_factory=list)
+
+    @classmethod
+    def from_samples(
+        cls,
+        template_id: str,
+        template_name: str,
+        sla_ms: int,
+        samples: List[ProbeExecutionSample],
+        notified_channels: Optional[List[NotificationChannel]] = None,
+    ) -> "ProbeExecutionSummary":
+        breach_count = sum(1 for sample in samples if sample.breach)
+        average_latency = mean(sample.latency_ms for sample in samples) if samples else 0.0
+        return cls(
+            template_id=template_id,
+            template_name=template_name,
+            sla_ms=sla_ms,
+            samples=samples,
+            average_latency_ms=round(average_latency, 2),
+            breach_count=breach_count,
+            met_sla=breach_count == 0,
+            notified_channels=notified_channels or [],
+        )
+
+
+class ProbeHistoryEntry(BaseModel):
+    template_id: str
+    recorded_at: datetime
+    summary: ProbeExecutionSummary
+
+
+class HeatmapCell(BaseModel):
+    timestamp: datetime
+    latency_ms: float
+    breach: bool
+
+
+class LatencyHeatmap(BaseModel):
+    template_id: str
+    columns: int
+    rows: List[List[HeatmapCell]]
+
+
+def utcnow() -> datetime:
+    return datetime.now(timezone.utc)

--- a/toolkits/latency_sleuth/backend/probes.py
+++ b/toolkits/latency_sleuth/backend/probes.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import random
+from datetime import datetime
+from typing import Iterable, List, Optional, Sequence
+
+from .models import (
+    NotificationChannel,
+    NotificationRule,
+    ProbeExecutionSample,
+    ProbeExecutionSummary,
+    ProbeTemplate,
+    utcnow,
+)
+
+
+def _deterministic_latency(template: ProbeTemplate, attempt: int) -> float:
+    seed = f"{template.id}:{attempt}:{template.sla_ms}:{template.interval_seconds}"
+    rng = random.Random(seed)
+    base = rng.uniform(20.0, template.sla_ms * 1.5 if template.sla_ms else 500.0)
+    jitter = rng.uniform(-0.1, 0.1) * base
+    latency = max(1.0, base + jitter)
+    return round(latency, 2)
+
+
+def _choose_latency(
+    template: ProbeTemplate,
+    attempt: int,
+    overrides: Optional[Sequence[float]] = None,
+) -> float:
+    if overrides and attempt - 1 < len(overrides):
+        return float(overrides[attempt - 1])
+    return _deterministic_latency(template, attempt)
+
+
+def _format_message(latency: float, sla_ms: int) -> str:
+    difference = latency - sla_ms
+    if difference <= 0:
+        return f"{latency:.2f} ms (within SLA)"
+    return f"{latency:.2f} ms (breach by {difference:.2f} ms)"
+
+
+def _should_notify(rule: NotificationRule, breach_count: int) -> bool:
+    if rule.threshold == "always":
+        return True
+    if rule.threshold == "breach":
+        return breach_count > 0
+    if rule.threshold == "recovery":
+        return breach_count == 0
+    return False
+
+
+def execute_probe(
+    template: ProbeTemplate,
+    sample_size: int,
+    overrides: Optional[Sequence[float]] = None,
+    clock: Optional[Iterable[datetime]] = None,
+) -> ProbeExecutionSummary:
+    if sample_size <= 0:
+        raise ValueError("sample_size must be positive")
+
+    timestamps = list(clock) if clock else []
+    samples: List[ProbeExecutionSample] = []
+    for attempt in range(1, sample_size + 1):
+        latency = _choose_latency(template, attempt, overrides=overrides)
+        timestamp = timestamps[attempt - 1] if attempt - 1 < len(timestamps) else utcnow()
+        breach = latency > template.sla_ms
+        samples.append(
+            ProbeExecutionSample(
+                attempt=attempt,
+                timestamp=timestamp,
+                latency_ms=latency,
+                breach=breach,
+                message=_format_message(latency, template.sla_ms),
+            )
+        )
+
+    summary = ProbeExecutionSummary.from_samples(
+        template_id=template.id,
+        template_name=template.name,
+        sla_ms=template.sla_ms,
+        samples=samples,
+        notified_channels=_select_channels(template.notification_rules, samples),
+    )
+    return summary
+
+
+def _select_channels(rules: Iterable[NotificationRule], samples: List[ProbeExecutionSample]) -> List[NotificationChannel]:
+    breach_count = sum(1 for sample in samples if sample.breach)
+    channels: List[NotificationChannel] = []
+    for rule in rules:
+        if _should_notify(rule, breach_count):
+            channels.append(rule.channel)
+    return channels

--- a/toolkits/latency_sleuth/backend/storage.py
+++ b/toolkits/latency_sleuth/backend/storage.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import json
+from typing import Iterable, List, Optional
+from uuid import uuid4
+
+from app.core.redis import get_redis, redis_key
+
+from .models import (
+    HeatmapCell,
+    LatencyHeatmap,
+    ProbeExecutionSummary,
+    ProbeHistoryEntry,
+    ProbeTemplate,
+    ProbeTemplateCreate,
+    ProbeTemplateUpdate,
+    utcnow,
+)
+
+
+TEMPLATES_KEY = redis_key("toolkits", "latency_sleuth", "templates")
+HISTORY_KEY_PREFIX = redis_key("toolkits", "latency_sleuth", "history")
+MAX_HISTORY_ENTRIES = 96
+MAX_HEATMAP_CELLS = 48
+DEFAULT_HEATMAP_COLUMNS = 6
+
+
+def _history_key(template_id: str) -> str:
+    return f"{HISTORY_KEY_PREFIX}:{template_id}"
+
+
+def _dump(data) -> str:
+    return json.dumps(data)
+
+
+def _load(raw: str):
+    return json.loads(raw)
+
+
+def _template_to_record(template: ProbeTemplate) -> dict:
+    return template.model_dump(mode="json")
+
+
+def _record_to_template(record: dict) -> ProbeTemplate:
+    return ProbeTemplate.model_validate(record)
+
+
+def _summary_to_entry(summary: ProbeExecutionSummary) -> ProbeHistoryEntry:
+    return ProbeHistoryEntry(template_id=summary.template_id, recorded_at=utcnow(), summary=summary)
+
+
+def create_template(payload: ProbeTemplateCreate) -> ProbeTemplate:
+    redis = get_redis()
+    template_id = str(uuid4())
+    now = utcnow()
+    template = ProbeTemplate(
+        id=template_id,
+        created_at=now,
+        updated_at=now,
+        **payload.model_dump(),
+    )
+    redis.hset(TEMPLATES_KEY, template_id, _dump(_template_to_record(template)))
+    return template
+
+
+def list_templates() -> List[ProbeTemplate]:
+    redis = get_redis()
+    values = redis.hvals(TEMPLATES_KEY) or []
+    return [_record_to_template(_load(value)) for value in values]
+
+
+def get_template(template_id: str) -> Optional[ProbeTemplate]:
+    redis = get_redis()
+    raw = redis.hget(TEMPLATES_KEY, template_id)
+    if not raw:
+        return None
+    return _record_to_template(_load(raw))
+
+
+def update_template(template_id: str, payload: ProbeTemplateUpdate) -> Optional[ProbeTemplate]:
+    current = get_template(template_id)
+    if not current:
+        return None
+    data = current.model_dump()
+    updates = payload.model_dump(exclude_none=True, exclude_unset=True)
+    data.update(updates)
+    updated = ProbeTemplate.model_validate({
+        **data,
+        "id": template_id,
+        "created_at": current.created_at,
+        "updated_at": utcnow(),
+    })
+    redis = get_redis()
+    redis.hset(TEMPLATES_KEY, template_id, _dump(_template_to_record(updated)))
+    return updated
+
+
+def delete_template(template_id: str) -> bool:
+    redis = get_redis()
+    removed = redis.hdel(TEMPLATES_KEY, template_id)
+    redis.delete(_history_key(template_id))
+    return bool(removed)
+
+
+def record_probe_result(summary: ProbeExecutionSummary) -> ProbeHistoryEntry:
+    redis = get_redis()
+    entry = _summary_to_entry(summary)
+    key = _history_key(summary.template_id)
+    redis.lpush(key, _dump(entry.model_dump(mode="json")))
+    redis.ltrim(key, 0, MAX_HISTORY_ENTRIES - 1)
+    return entry
+
+
+def list_history(template_id: str, limit: int = MAX_HISTORY_ENTRIES) -> List[ProbeHistoryEntry]:
+    redis = get_redis()
+    raw_values = redis.lrange(_history_key(template_id), 0, limit - 1)
+    history: List[ProbeHistoryEntry] = []
+    for raw in raw_values:
+        history.append(ProbeHistoryEntry.model_validate(_load(raw)))
+    return history
+
+
+def build_heatmap(template_id: str, columns: int = DEFAULT_HEATMAP_COLUMNS) -> LatencyHeatmap:
+    history = list_history(template_id, limit=MAX_HEATMAP_CELLS)
+    if not history:
+        return LatencyHeatmap(template_id=template_id, columns=columns, rows=[])
+
+    samples: List[HeatmapCell] = []
+    for entry in reversed(history):
+        for sample in entry.summary.samples:
+            samples.append(
+                HeatmapCell(
+                    timestamp=sample.timestamp,
+                    latency_ms=sample.latency_ms,
+                    breach=sample.breach,
+                )
+            )
+    samples = samples[-MAX_HEATMAP_CELLS:]
+
+    rows: List[List[HeatmapCell]] = []
+    if columns <= 0:
+        columns = DEFAULT_HEATMAP_COLUMNS
+    for index in range(0, len(samples), columns):
+        rows.append(samples[index : index + columns])
+    return LatencyHeatmap(template_id=template_id, columns=columns, rows=rows)
+
+
+def reset_storage() -> None:
+    """Utility used in tests to clear stored data."""
+
+    redis = get_redis()
+    redis.delete(TEMPLATES_KEY)
+    history_keys: Iterable[str] = redis.scan_iter(f"{_history_key('*')}")  # type: ignore[arg-type]
+    for key in list(history_keys):
+        redis.delete(key)

--- a/toolkits/latency_sleuth/docs/OPERATOR.md
+++ b/toolkits/latency_sleuth/docs/OPERATOR.md
@@ -1,0 +1,54 @@
+# Latency Sleuth Operator Guide
+
+Latency Sleuth provisions repeatable HTTP probes so SREs can tune alert windows before shipping changes to production. Use this
+reference when onboarding a new service or adjusting SLAs after an incident.
+
+## Designing a Probe Template
+1. Open **Toolkits → Synthetic Probes**.
+2. Use the **Probe Designer** to define:
+   - **Target URL** – the endpoint you expect to respond quickly.
+   - **HTTP Method** – `GET`, `HEAD`, or `POST` depending on the cheapest call that exercises the dependency chain.
+   - **Latency SLA (ms)** – breach threshold for a single attempt.
+   - **Interval (seconds)** – cadence for scheduled runs. Keep values above 30 seconds to avoid overwhelming fragile hosts.
+   - **Notification Rules** – choose Slack, email, PagerDuty, or webhook targets. Rules fire on breaches by default; set the
+     threshold to `always` to receive every sample or `recovery` to confirm when latency stabilises.
+3. Tag templates with service identifiers so heatmaps group logically in the overview.
+4. Save the template. The catalog lists creation/update times and serves as the source of truth for change reviews.
+
+## Tuning SLAs
+- Start with the 95th percentile of production latency plus a 10% buffer.
+- After a week of historical data, review the **Latency Heatmap** for streaks of breaches.
+- Adjust the SLA upward when synthetic probes regularly breach but user experience remains healthy.
+- Lower the SLA cautiously to detect regressions earlier, validating that your on-call rotation can absorb the alert volume.
+
+## Alert Wiring
+- Slack targets work best for daytime signal; use dedicated channels per service to preserve history.
+- PagerDuty alerts should reference runbook URLs in the webhook payload so responders can escalate quickly.
+- When chaining to a webhook, expect a JSON body shaped like:
+  ```json
+  {
+    "template_id": "uuid",
+    "template_name": "Checkout API",
+    "breach_count": 2,
+    "average_latency_ms": 640.5,
+    "samples": [
+      { "attempt": 1, "latency_ms": 602.1, "breach": true },
+      { "attempt": 2, "latency_ms": 678.9, "breach": true }
+    ]
+  }
+  ```
+- Use the **Job Log Viewer** to verify notifications after editing rules. The viewer streams live logs from the shared Redis
+  store so you can trace cancellations and worker retries.
+
+## Release Process
+1. Run the toolkit unit tests:
+   ```bash
+   pytest toolkits/latency_sleuth/tests
+   npm --prefix frontend test -- --run toolkits/latency_sleuth/frontend
+   ```
+2. Package the bundle using `toolkits/scripts/package_toolkit.py`.
+3. Attach `latency-sleuth_toolkit.zip` and updated release notes to your distribution channel.
+4. After installation, confirm the dashboard card links to `/toolkits/latency-sleuth`.
+
+For troubleshooting, inspect Celery worker logs for `latency-sleuth.run_probe` entries and check Redis keys prefixed with
+`toolkits:latency_sleuth` to ensure telemetry is flowing.

--- a/toolkits/latency_sleuth/frontend/components/JobLogViewer.tsx
+++ b/toolkits/latency_sleuth/frontend/components/JobLogViewer.tsx
@@ -1,0 +1,155 @@
+import { apiFetch, getReactRuntime } from '../runtime'
+import { useProbeTemplates } from '../hooks/useProbeTemplates'
+import { useJobStream } from '../hooks/useJobStream'
+import type { ProbeExecutionSummary } from '../types'
+
+const React = getReactRuntime()
+const { useMemo, useState } = React
+
+export default function JobLogViewer() {
+  const { templates, loading: templatesLoading, error: templatesError } = useProbeTemplates()
+  const [selectedTemplate, setSelectedTemplate] = useState<string | null>(null)
+  const [jobId, setJobId] = useState<string | null>(null)
+  const [preview, setPreview] = useState<ProbeExecutionSummary | null>(null)
+  const [status, setStatus] = useState<string | null>(null)
+  const { job, loading: jobLoading, error: jobError, refresh } = useJobStream(jobId)
+
+  const templateOptions = useMemo(
+    () =>
+      templates.map((template) => ({
+        id: template.id,
+        label: `${template.name} – SLA ${template.sla_ms}ms`,
+      })),
+    [templates],
+  )
+
+  const currentTemplate = useMemo(
+    () => templates.find((template) => template.id === selectedTemplate) ?? null,
+    [templates, selectedTemplate],
+  )
+
+  const triggerPreview = async () => {
+    if (!currentTemplate) return
+    try {
+      const response = await apiFetch<ProbeExecutionSummary>(
+        `/toolkits/latency-sleuth/probe-templates/${currentTemplate.id}/actions/preview`,
+        { method: 'POST', json: { sample_size: 3 } },
+      )
+      setPreview(response)
+      setStatus('Preview generated')
+    } catch (err) {
+      setStatus(err instanceof Error ? err.message : 'Failed to preview probe')
+    }
+  }
+
+  const triggerRun = async () => {
+    if (!currentTemplate) return
+    setStatus(null)
+    setJobId(null)
+    try {
+      const response = await apiFetch<{ job: { id: string } }>(
+        `/toolkits/latency-sleuth/probe-templates/${currentTemplate.id}/actions/run`,
+        { method: 'POST', json: { sample_size: 3 } },
+      )
+      setJobId(response.job.id)
+      setStatus('Probe dispatched to workers')
+    } catch (err) {
+      setStatus(err instanceof Error ? err.message : 'Failed to start probe')
+    }
+  }
+
+  const renderLogs = () => {
+    if (!job) {
+      return <p style={{ color: 'var(--color-text-secondary)' }}>Select a template and run a probe to stream logs.</p>
+    }
+
+    return (
+      <div style={{ display: 'grid', gap: '0.5rem' }}>
+        <header style={{ display: 'flex', gap: '0.75rem', alignItems: 'center' }}>
+          <strong>Job status: {job.status}</strong>
+          <span>Progress: {job.progress}%</span>
+          <button type="button" className="tk-button" onClick={() => refresh()} disabled={jobLoading}>
+            Refresh
+          </button>
+        </header>
+        <div className="tk-log-viewer">
+          <ul style={{ margin: 0, padding: 0, listStyle: 'none', display: 'grid', gap: '0.35rem' }}>
+            {job.logs.map((log) => (
+              <li key={log.ts} style={{ fontFamily: 'var(--font-mono)' }}>
+                <span style={{ color: 'var(--color-text-secondary)' }}>{new Date(log.ts).toLocaleTimeString()} </span>
+                {log.message}
+              </li>
+            ))}
+          </ul>
+        </div>
+        {job.result && (
+          <pre className="tk-code-block" style={{ whiteSpace: 'pre-wrap' }}>
+            {JSON.stringify(job.result, null, 2)}
+          </pre>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div className="tk-card" style={{ padding: '1.25rem', display: 'grid', gap: '1rem' }}>
+      <header>
+        <h3 style={{ margin: 0 }}>Job Log Viewer</h3>
+        <p style={{ margin: '0.25rem 0 0', color: 'var(--color-text-secondary)' }}>
+          Dispatch probes and stream worker logs directly from Redis telemetry.
+        </p>
+      </header>
+
+      <div style={{ display: 'grid', gap: '0.75rem' }}>
+        <label className="tk-field-label">
+          Probe template
+          <select
+            className="tk-select"
+            value={selectedTemplate ?? ''}
+            onChange={(event) => setSelectedTemplate(event.target.value || null)}
+          >
+            <option value="" disabled>
+              {templatesLoading ? 'Loading templates…' : 'Choose a template'}
+            </option>
+            {templateOptions.map((template) => (
+              <option key={template.id} value={template.id}>
+                {template.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        {templatesError && <span style={{ color: 'var(--color-status-error)' }}>{templatesError}</span>}
+
+        <div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap' }}>
+          <button className="tk-button" type="button" onClick={triggerPreview} disabled={!currentTemplate}>
+            Preview run
+          </button>
+          <button className="tk-button tk-button--primary" type="button" onClick={triggerRun} disabled={!currentTemplate}>
+            Run probe
+          </button>
+          {status && <span style={{ color: 'var(--color-text-secondary)' }}>{status}</span>}
+          {jobError && <span style={{ color: 'var(--color-status-error)' }}>{jobError}</span>}
+        </div>
+      </div>
+
+      {preview && (
+        <section className="tk-card" style={{ background: 'var(--color-surface-muted)', padding: '1rem' }}>
+          <h4 style={{ marginTop: 0 }}>Preview summary</h4>
+          <p style={{ margin: '0 0 0.5rem' }}>
+            Average latency {preview.average_latency_ms} ms with {preview.breach_count} breach(es).
+          </p>
+          <ul style={{ margin: 0, paddingLeft: '1.25rem', display: 'grid', gap: '0.25rem' }}>
+            {preview.samples.map((sample) => (
+              <li key={sample.attempt}>
+                Attempt {sample.attempt}: {sample.latency_ms} ms – {sample.breach ? 'breach' : 'ok'}
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      <section>{renderLogs()}</section>
+    </div>
+  )
+}

--- a/toolkits/latency_sleuth/frontend/components/LatencyHeatmap.tsx
+++ b/toolkits/latency_sleuth/frontend/components/LatencyHeatmap.tsx
@@ -1,0 +1,127 @@
+import { apiFetch, getReactRuntime } from '../runtime'
+import { useProbeTemplates } from '../hooks/useProbeTemplates'
+import type { HeatmapCell, LatencyHeatmap } from '../types'
+
+const React = getReactRuntime()
+const { useEffect, useMemo, useState } = React
+
+function cellColor(cell: HeatmapCell) {
+  if (cell.breach) {
+    return 'var(--color-status-error-muted)'
+  }
+  return 'var(--color-status-success-muted)'
+}
+
+export default function LatencyHeatmapView() {
+  const { templates, loading: templatesLoading, error: templatesError } = useProbeTemplates()
+  const [selectedTemplate, setSelectedTemplate] = useState<string | null>(null)
+  const [heatmap, setHeatmap] = useState<LatencyHeatmap | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const currentTemplate = useMemo(
+    () => templates.find((template) => template.id === selectedTemplate) ?? null,
+    [templates, selectedTemplate],
+  )
+
+  useEffect(() => {
+    if (!currentTemplate) {
+      setHeatmap(null)
+      return
+    }
+
+    let cancelled = false
+    const fetchHeatmap = async () => {
+      setLoading(true)
+      setError(null)
+      try {
+        const response = await apiFetch<LatencyHeatmap>(
+          `/toolkits/latency-sleuth/probe-templates/${currentTemplate.id}/heatmap`,
+          { method: 'GET' },
+        )
+        if (!cancelled) {
+          setHeatmap(response)
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to load heatmap')
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false)
+        }
+      }
+    }
+
+    fetchHeatmap()
+
+    return () => {
+      cancelled = true
+    }
+  }, [currentTemplate])
+
+  const renderGrid = () => {
+    if (!heatmap || heatmap.rows.length === 0) {
+      return <p style={{ color: 'var(--color-text-secondary)' }}>No probe executions recorded yet.</p>
+    }
+
+    return (
+      <div style={{ display: 'grid', gap: '0.75rem' }}>
+        {heatmap.rows.map((row, rowIndex) => (
+          <div key={rowIndex} style={{ display: 'grid', gap: '0.5rem', gridTemplateColumns: `repeat(${heatmap.columns}, minmax(40px, 1fr))` }}>
+            {row.map((cell, cellIndex) => (
+              <div
+                key={cellIndex}
+                title={`${new Date(cell.timestamp).toLocaleString()} — ${cell.latency_ms} ms`}
+                style={{
+                  padding: '0.65rem 0.35rem',
+                  textAlign: 'center',
+                  borderRadius: 6,
+                  background: cellColor(cell),
+                  color: cell.breach ? 'var(--color-status-error-text)' : 'var(--color-status-success-text)',
+                  fontWeight: 600,
+                }}
+              >
+                {Math.round(cell.latency_ms)}
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+    )
+  }
+
+  return (
+    <div className="tk-card" style={{ padding: '1.25rem', display: 'grid', gap: '1rem' }}>
+      <header>
+        <h3 style={{ margin: 0 }}>Latency Heatmap</h3>
+        <p style={{ margin: '0.25rem 0 0', color: 'var(--color-text-secondary)' }}>
+          Spot drift in synthetic response times and correlate with SLA breaches.
+        </p>
+      </header>
+
+      <label className="tk-field-label">
+        Probe template
+        <select
+          className="tk-select"
+          value={selectedTemplate ?? ''}
+          onChange={(event) => setSelectedTemplate(event.target.value || null)}
+        >
+          <option value="" disabled>
+            {templatesLoading ? 'Loading templates…' : 'Choose a template'}
+          </option>
+          {templates.map((template) => (
+            <option key={template.id} value={template.id}>
+              {template.name}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      {templatesError && <span style={{ color: 'var(--color-status-error)' }}>{templatesError}</span>}
+      {error && <span style={{ color: 'var(--color-status-error)' }}>{error}</span>}
+
+      {loading ? <p>Loading heatmap…</p> : renderGrid()}
+    </div>
+  )
+}

--- a/toolkits/latency_sleuth/frontend/components/ProbeDesigner.tsx
+++ b/toolkits/latency_sleuth/frontend/components/ProbeDesigner.tsx
@@ -1,0 +1,291 @@
+import { getReactRuntime } from '../runtime'
+import { useProbeTemplates } from '../hooks/useProbeTemplates'
+import type { NotificationRule, ProbeTemplateCreate } from '../types'
+
+const React = getReactRuntime()
+const { useMemo, useState } = React
+
+const methods: ProbeTemplateCreate['method'][] = ['GET', 'HEAD', 'POST']
+const channels: NotificationRule['channel'][] = ['slack', 'email', 'pagerduty', 'webhook']
+const thresholds: NotificationRule['threshold'][] = ['breach', 'always', 'recovery']
+
+const formDefaults: ProbeTemplateCreate = {
+  name: '',
+  url: 'https://example.com/healthz',
+  method: 'GET',
+  sla_ms: 500,
+  interval_seconds: 300,
+  notification_rules: [],
+  tags: [],
+}
+
+export default function ProbeDesigner() {
+  const { templates, createTemplate, removeTemplate, loading, error } = useProbeTemplates()
+  const [formState, setFormState] = useState(formDefaults)
+  const [status, setStatus] = useState<string | null>(null)
+
+  const sortedTemplates = useMemo(
+    () =>
+      [...templates].sort(
+        (a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
+      ),
+    [templates],
+  )
+
+  const handleSubmit = async (event: any) => {
+    event.preventDefault()
+    setStatus(null)
+    try {
+      const payload: ProbeTemplateCreate = {
+        ...formState,
+        notification_rules: formState.notification_rules?.filter((rule) => rule.target.trim().length > 0),
+        tags: formState.tags?.filter(Boolean) ?? [],
+      }
+      await createTemplate(payload)
+      setFormState(formDefaults)
+      setStatus('Probe template created')
+    } catch (err) {
+      setStatus(err instanceof Error ? err.message : 'Failed to create template')
+    }
+  }
+
+  const handleRuleChange = (index: number, key: keyof NotificationRule, value: string) => {
+    setFormState((prev) => {
+      const rules = [...(prev.notification_rules ?? [])]
+      const current = rules[index] ?? { channel: 'slack', target: '', threshold: 'breach' }
+      rules[index] = { ...current, [key]: value }
+      return { ...prev, notification_rules: rules }
+    })
+  }
+
+  const addRule = () => {
+    setFormState((prev) => ({
+      ...prev,
+      notification_rules: [...(prev.notification_rules ?? []), { channel: 'slack', target: '', threshold: 'breach' }],
+    }))
+  }
+
+  const removeRule = (index: number) => {
+    setFormState((prev) => ({
+      ...prev,
+      notification_rules: (prev.notification_rules ?? []).filter((_, idx) => idx !== index),
+    }))
+  }
+
+  const updateTag = (index: number, value: string) => {
+    setFormState((prev) => {
+      const tags = [...(prev.tags ?? [])]
+      tags[index] = value
+      return { ...prev, tags }
+    })
+  }
+
+  const addTag = () => {
+    setFormState((prev) => ({ ...prev, tags: [...(prev.tags ?? []), ''] }))
+  }
+
+  const removeTag = (index: number) => {
+    setFormState((prev) => ({
+      ...prev,
+      tags: (prev.tags ?? []).filter((_, idx) => idx !== index),
+    }))
+  }
+
+  return (
+    <div style={{ display: 'grid', gap: '1.25rem' }}>
+      <section className="tk-card" style={{ padding: '1.25rem', display: 'grid', gap: '1rem' }}>
+        <header>
+          <h3 style={{ margin: 0 }}>Probe Designer</h3>
+          <p style={{ margin: '0.25rem 0 0', color: 'var(--color-text-secondary)' }}>
+            Model SLAs, tags, and notification policies before releasing synthetic probes.
+          </p>
+        </header>
+
+        <form onSubmit={handleSubmit} style={{ display: 'grid', gap: '0.75rem' }}>
+          <div>
+            <label className="tk-field-label">Name</label>
+            <input
+              className="tk-input"
+              required
+              value={formState.name}
+              onChange={(event) => setFormState((prev) => ({ ...prev, name: event.target.value }))}
+            />
+          </div>
+
+          <div>
+            <label className="tk-field-label">URL</label>
+            <input
+              className="tk-input"
+              required
+              type="url"
+              value={formState.url}
+              onChange={(event) => setFormState((prev) => ({ ...prev, url: event.target.value }))}
+            />
+          </div>
+
+          <div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap' }}>
+            <label className="tk-field-label" style={{ flex: '1 0 200px' }}>
+              Method
+              <select
+                className="tk-select"
+                value={formState.method}
+                onChange={(event) => setFormState((prev) => ({ ...prev, method: event.target.value as typeof prev.method }))}
+              >
+                {methods.map((method) => (
+                  <option key={method}>{method}</option>
+                ))}
+              </select>
+            </label>
+
+            <label className="tk-field-label" style={{ flex: '1 0 200px' }}>
+              SLA (ms)
+              <input
+                className="tk-input"
+                required
+                type="number"
+                min={10}
+                value={formState.sla_ms}
+                onChange={(event) => setFormState((prev) => ({ ...prev, sla_ms: Number(event.target.value) }))}
+              />
+            </label>
+
+            <label className="tk-field-label" style={{ flex: '1 0 200px' }}>
+              Interval (seconds)
+              <input
+                className="tk-input"
+                type="number"
+                min={30}
+                value={formState.interval_seconds ?? 300}
+                onChange={(event) =>
+                  setFormState((prev) => ({ ...prev, interval_seconds: Number(event.target.value) }))
+                }
+              />
+            </label>
+          </div>
+
+          <div>
+            <label className="tk-field-label" style={{ marginBottom: '0.3rem' }}>Notification Rules</label>
+            <div style={{ display: 'grid', gap: '0.5rem' }}>
+              {(formState.notification_rules ?? []).map((rule, index) => (
+                <div
+                  key={index}
+                  style={{ display: 'grid', gap: '0.5rem', gridTemplateColumns: 'repeat(3, minmax(120px, 1fr)) auto' }}
+                >
+                  <select
+                    className="tk-select"
+                    value={rule.channel}
+                    onChange={(event) => handleRuleChange(index, 'channel', event.target.value)}
+                  >
+                    {channels.map((channel) => (
+                      <option key={channel} value={channel}>
+                        {channel}
+                      </option>
+                    ))}
+                  </select>
+                  <input
+                    className="tk-input"
+                    placeholder="Target"
+                    value={rule.target}
+                    onChange={(event) => handleRuleChange(index, 'target', event.target.value)}
+                  />
+                  <select
+                    className="tk-select"
+                    value={rule.threshold}
+                    onChange={(event) => handleRuleChange(index, 'threshold', event.target.value)}
+                  >
+                    {thresholds.map((threshold) => (
+                      <option key={threshold} value={threshold}>
+                        {threshold}
+                      </option>
+                    ))}
+                  </select>
+                  <button type="button" className="tk-button" onClick={() => removeRule(index)}>
+                    Remove
+                  </button>
+                </div>
+              ))}
+              <button type="button" className="tk-button" onClick={addRule}>
+                Add rule
+              </button>
+            </div>
+          </div>
+
+          <div>
+            <label className="tk-field-label" style={{ marginBottom: '0.3rem' }}>Tags</label>
+            <div style={{ display: 'grid', gap: '0.5rem' }}>
+              {(formState.tags ?? []).map((tag, index) => (
+                <div key={index} style={{ display: 'flex', gap: '0.5rem' }}>
+                  <input
+                    className="tk-input"
+                    placeholder="service:web"
+                    value={tag}
+                    onChange={(event) => updateTag(index, event.target.value)}
+                  />
+                  <button type="button" className="tk-button" onClick={() => removeTag(index)}>
+                    Remove
+                  </button>
+                </div>
+              ))}
+              <button type="button" className="tk-button" onClick={addTag}>
+                Add tag
+              </button>
+            </div>
+          </div>
+
+          <div style={{ display: 'flex', gap: '0.75rem', alignItems: 'center' }}>
+            <button type="submit" className="tk-button tk-button--primary" disabled={loading}>
+              Create template
+            </button>
+            {status && <span style={{ color: 'var(--color-text-secondary)' }}>{status}</span>}
+            {error && <span style={{ color: 'var(--color-status-error)' }}>{error}</span>}
+          </div>
+        </form>
+      </section>
+
+      <section className="tk-card" style={{ padding: '1.25rem' }}>
+        <header style={{ marginBottom: '0.75rem' }}>
+          <h3 style={{ margin: 0 }}>Template Catalog</h3>
+        </header>
+        <div style={{ overflowX: 'auto' }}>
+          <table className="tk-table">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>URL</th>
+                <th>SLA (ms)</th>
+                <th>Interval</th>
+                <th>Tags</th>
+                <th>Updated</th>
+                <th />
+              </tr>
+            </thead>
+            <tbody>
+              {sortedTemplates.map((template) => (
+                <tr key={template.id}>
+                  <td>{template.name}</td>
+                  <td style={{ maxWidth: 240, wordBreak: 'break-all' }}>{template.url}</td>
+                  <td>{template.sla_ms}</td>
+                  <td>{template.interval_seconds}s</td>
+                  <td>{template.tags.join(', ')}</td>
+                  <td>{new Date(template.updated_at).toLocaleString()}</td>
+                  <td>
+                    <button className="tk-button" type="button" onClick={() => removeTemplate(template.id)}>
+                      Delete
+                    </button>
+                  </td>
+                </tr>
+              ))}
+              {sortedTemplates.length === 0 && (
+                <tr>
+                  <td colSpan={7} style={{ textAlign: 'center', padding: '1rem' }}>
+                    {loading ? 'Loading templates…' : 'No templates captured yet.'}
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/toolkits/latency_sleuth/frontend/hooks/__tests__/useProbeTemplates.test.tsx
+++ b/toolkits/latency_sleuth/frontend/hooks/__tests__/useProbeTemplates.test.tsx
@@ -1,0 +1,240 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+
+import type { ToolkitRuntime } from '../../runtime'
+
+let useProbeTemplates: typeof import('../useProbeTemplates')['useProbeTemplates']
+
+if (typeof (globalThis as any).window === 'undefined') {
+  ;(globalThis as any).window = {} as any
+}
+
+let activeReact: FakeReact = createFakeReact()
+
+const reactProxy: Partial<FakeReact> = {
+  useState: (...args: Parameters<FakeReact['useState']>) => activeReact.useState(...(args as [unknown])),
+  useRef: (...args: Parameters<FakeReact['useRef']>) => activeReact.useRef(...args),
+  useMemo: (...args: Parameters<FakeReact['useMemo']>) => activeReact.useMemo(...args),
+  useCallback: (...args: Parameters<FakeReact['useCallback']>) => activeReact.useCallback(...args),
+  useEffect: (...args: Parameters<FakeReact['useEffect']>) => activeReact.useEffect(...args),
+}
+
+type StateUpdater<T> = (value: T | ((prev: T) => T)) => void
+
+type FakeReact = {
+  useState<T>(initial: T): [T, StateUpdater<T>]
+  useRef<T>(initial: T): { current: T }
+  useMemo<T>(factory: () => T, deps?: unknown[]): T
+  useCallback<T extends (...args: any[]) => any>(fn: T, deps?: unknown[]): T
+  useEffect(effect: () => void | (() => void), deps?: unknown[]): void
+  run<T>(callback: () => T): T
+}
+
+function depsChanged(prev: unknown[] | undefined, next: unknown[]): boolean {
+  if (!prev) return true
+  if (prev.length !== next.length) return true
+  for (let index = 0; index < prev.length; index += 1) {
+    if (!Object.is(prev[index], next[index])) {
+      return true
+    }
+  }
+  return false
+}
+
+function createFakeReact(): FakeReact {
+  const states: unknown[] = []
+  const refs: unknown[] = []
+  const memoValues: unknown[] = []
+  const memoDeps: (unknown[] | undefined)[] = []
+  const effectDeps: (unknown[] | undefined)[] = []
+  const cleanupFns: (void | (() => void))[] = []
+  const pendingEffects: Array<{ index: number; effect: () => void | (() => void) }> = []
+  let cursor = 0
+
+  function useState<T>(initial: T): [T, StateUpdater<T>] {
+    const index = cursor++
+    if (!(index in states)) {
+      states[index] = typeof initial === 'function' ? (initial as () => T)() : initial
+    }
+    const setState: StateUpdater<T> = (value) => {
+      const next = typeof value === 'function' ? (value as (prev: T) => T)(states[index] as T) : value
+      states[index] = next
+    }
+    return [states[index] as T, setState]
+  }
+
+  function useRef<T>(initial: T): { current: T } {
+    const index = cursor++
+    if (!(index in refs)) {
+      refs[index] = { current: initial }
+    }
+    return refs[index] as { current: T }
+  }
+
+  function useMemo<T>(factory: () => T, deps: unknown[] = []): T {
+    const index = cursor++
+    if (!memoDeps[index] || depsChanged(memoDeps[index], deps)) {
+      memoValues[index] = factory()
+      memoDeps[index] = deps.slice()
+    }
+    return memoValues[index] as T
+  }
+
+  function useCallback<T extends (...args: any[]) => any>(fn: T, deps: unknown[] = []): T {
+    return useMemo(() => fn, deps)
+  }
+
+  function useEffect(effect: () => void | (() => void), deps: unknown[] = []): void {
+    const index = cursor++
+    if (!effectDeps[index] || depsChanged(effectDeps[index], deps)) {
+      effectDeps[index] = deps.slice()
+      pendingEffects.push({ index, effect })
+    }
+  }
+
+  function run<T>(callback: () => T): T {
+    cursor = 0
+    const result = callback()
+    cursor = 0
+    while (pendingEffects.length > 0) {
+      const { index, effect } = pendingEffects.shift()!
+      if (typeof cleanupFns[index] === 'function') {
+        ;(cleanupFns[index] as () => void)()
+      }
+      cleanupFns[index] = effect()
+    }
+    return result
+  }
+
+  return {
+    useState,
+    useRef,
+    useMemo,
+    useCallback,
+    useEffect,
+    run,
+  }
+}
+
+function renderHook<T>(callback: () => T) {
+  const runtime = window.__SRE_TOOLKIT_RUNTIME!
+  const fakeReact = createFakeReact()
+  activeReact = fakeReact
+  runtime.react = reactProxy as any
+
+  let current: T
+  const rerender = () => {
+    current = fakeReact.run(callback)
+  }
+
+  rerender()
+
+  return {
+    result: {
+      get current() {
+        return current
+      },
+    },
+    rerender,
+  }
+}
+
+beforeEach(async () => {
+  await vi.resetModules()
+  activeReact = createFakeReact()
+  const runtime: ToolkitRuntime = {
+    react: reactProxy as any,
+    reactRouterDom: {} as any,
+    apiFetch: vi.fn(),
+  }
+  window.__SRE_TOOLKIT_RUNTIME = runtime
+  useProbeTemplates = (await import('../useProbeTemplates')).useProbeTemplates
+})
+
+afterEach(() => {
+  delete window.__SRE_TOOLKIT_RUNTIME
+  activeReact = createFakeReact()
+})
+
+describe('useProbeTemplates', () => {
+  it('loads templates on mount', async () => {
+    const templates = [
+      {
+        id: 't-1',
+        name: 'Checkout',
+        description: null,
+        url: 'https://example.com/checkout',
+        method: 'GET' as const,
+        sla_ms: 420,
+        interval_seconds: 120,
+        notification_rules: [],
+        tags: [],
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      },
+    ]
+    const apiFetch = vi.fn().mockResolvedValue(templates)
+    window.__SRE_TOOLKIT_RUNTIME!.apiFetch = apiFetch
+
+    const hook = renderHook(() => useProbeTemplates())
+
+    expect(apiFetch).toHaveBeenCalledWith('/toolkits/latency-sleuth/probe-templates', expect.any(Object))
+
+    await hook.result.current.refresh()
+    hook.rerender()
+
+    expect(hook.result.current.templates).toHaveLength(1)
+    expect(hook.result.current.templates[0].name).toBe('Checkout')
+  })
+
+  it('creates templates and updates state', async () => {
+    const templates: any[] = []
+    const apiFetch = vi.fn().mockImplementation(async (path: string, options?: RequestInit & { json?: unknown }) => {
+      if (options?.method === 'POST') {
+        const payload = options.json as any
+        const created = {
+          id: 'generated',
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+          notification_rules: [],
+          tags: [],
+          method: 'GET',
+          interval_seconds: 300,
+          ...payload,
+        }
+        templates.push(created)
+        return created
+      }
+      if (options?.method === 'DELETE') {
+        const targetId = path.split('/').pop()
+        const index = templates.findIndex((item) => item.id === targetId)
+        if (index >= 0) {
+          templates.splice(index, 1)
+        }
+        return null
+      }
+      return templates.slice()
+    })
+    window.__SRE_TOOLKIT_RUNTIME!.apiFetch = apiFetch
+
+    const hook = renderHook(() => useProbeTemplates())
+
+    await Promise.resolve()
+    hook.rerender()
+
+    await hook.result.current.createTemplate({ name: 'Checkout', url: 'https://example.com', sla_ms: 400 })
+    hook.rerender()
+
+    const postCall = apiFetch.mock.calls.find(([, options]) => (options as RequestInit | undefined)?.method === 'POST')
+    expect(postCall?.[1]?.method).toBe('POST')
+    expect(postCall?.[1]?.body).toBe(JSON.stringify({ name: 'Checkout', url: 'https://example.com', sla_ms: 400 }))
+    expect(hook.result.current.templates).toHaveLength(1)
+
+    await hook.result.current.removeTemplate('generated')
+    hook.rerender()
+
+    const deleteCall = apiFetch.mock.calls.find(([path]) => path === '/toolkits/latency-sleuth/probe-templates/generated')
+    expect(deleteCall).toBeTruthy()
+    expect(deleteCall?.[1]?.method).toBe('DELETE')
+    expect(hook.result.current.templates).toHaveLength(0)
+  })
+})

--- a/toolkits/latency_sleuth/frontend/hooks/useJobStream.ts
+++ b/toolkits/latency_sleuth/frontend/hooks/useJobStream.ts
@@ -1,0 +1,83 @@
+import { apiFetch, getReactRuntime } from '../runtime'
+import type { JobRecord } from '../types'
+
+const React = getReactRuntime()
+const { useCallback, useEffect, useRef, useState } = React
+
+const TERMINAL_STATUSES = new Set(['succeeded', 'failed', 'cancelled'])
+
+export function useJobStream(jobId: string | null, pollInterval = 2000) {
+  const [job, setJob] = useState<JobRecord | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const activeRef = useRef(true)
+
+  useEffect(() => {
+    activeRef.current = true
+    return () => {
+      activeRef.current = false
+    }
+  }, [])
+
+  const fetchJob = useCallback(
+    async (currentJobId: string) => {
+      setLoading(true)
+      try {
+        const response = await apiFetch<JobRecord>(
+          `/toolkits/latency-sleuth/jobs/${currentJobId}`,
+        )
+        if (!activeRef.current) return response
+        setJob(response)
+        setError(null)
+        return response
+      } catch (err) {
+        if (!activeRef.current) return null
+        setError(err instanceof Error ? err.message : 'Failed to load job status')
+        throw err
+      } finally {
+        if (activeRef.current) {
+          setLoading(false)
+        }
+      }
+    },
+    [],
+  )
+
+  useEffect(() => {
+    if (!jobId) {
+      setJob(null)
+      setError(null)
+      setLoading(false)
+      return () => {}
+    }
+
+    let cancelled = false
+    let timer: ReturnType<typeof setTimeout> | undefined
+
+    const poll = async () => {
+      try {
+        const response = await fetchJob(jobId)
+        if (!response || TERMINAL_STATUSES.has(response.status) || cancelled) {
+          return
+        }
+        timer = setTimeout(poll, pollInterval)
+      } catch {
+        timer = setTimeout(poll, pollInterval * 2)
+      }
+    }
+
+    poll()
+
+    return () => {
+      cancelled = true
+      if (timer) clearTimeout(timer)
+    }
+  }, [jobId, pollInterval, fetchJob])
+
+  return {
+    job,
+    loading,
+    error,
+    refresh: jobId ? () => fetchJob(jobId) : async () => null,
+  }
+}

--- a/toolkits/latency_sleuth/frontend/hooks/useProbeTemplates.ts
+++ b/toolkits/latency_sleuth/frontend/hooks/useProbeTemplates.ts
@@ -1,0 +1,97 @@
+import { apiFetch, getReactRuntime } from '../runtime'
+import type { ProbeTemplate, ProbeTemplateCreate } from '../types'
+
+const React = getReactRuntime()
+const { useCallback, useEffect, useMemo, useRef, useState } = React
+
+export function useProbeTemplates() {
+  const [templates, setTemplates] = useState<ProbeTemplate[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const activeRef = useRef(true)
+
+  useEffect(() => {
+    activeRef.current = true
+    return () => {
+      activeRef.current = false
+    }
+  }, [])
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const response = await apiFetch<ProbeTemplate[]>(
+        '/toolkits/latency-sleuth/probe-templates',
+      )
+      if (!activeRef.current) return
+      response.sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime())
+      setTemplates(response)
+    } catch (err) {
+      if (!activeRef.current) return
+      setError(err instanceof Error ? err.message : 'Failed to load templates')
+    } finally {
+      if (activeRef.current) {
+        setLoading(false)
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  const createTemplate = useCallback(
+    async (payload: ProbeTemplateCreate) => {
+      const created = await apiFetch<ProbeTemplate>(
+        '/toolkits/latency-sleuth/probe-templates',
+        { method: 'POST', json: payload },
+      )
+      if (activeRef.current) {
+        setTemplates((prev) => [...prev, created])
+      }
+      return created
+    },
+    [],
+  )
+
+  const updateTemplate = useCallback(
+    async (templateId: string, payload: Partial<ProbeTemplateCreate>) => {
+      const updated = await apiFetch<ProbeTemplate>(
+        `/toolkits/latency-sleuth/probe-templates/${templateId}`,
+        { method: 'PUT', json: payload },
+      )
+      if (activeRef.current) {
+        setTemplates((prev) => prev.map((item) => (item.id === templateId ? updated : item)))
+      }
+      return updated
+    },
+    [],
+  )
+
+  const removeTemplate = useCallback(async (templateId: string) => {
+    await apiFetch(`/toolkits/latency-sleuth/probe-templates/${templateId}`, { method: 'DELETE' })
+    if (activeRef.current) {
+      setTemplates((prev) => prev.filter((item) => item.id !== templateId))
+    }
+  }, [])
+
+  const templatesById = useMemo(() => {
+    const map = new Map<string, ProbeTemplate>()
+    for (const template of templates) {
+      map.set(template.id, template)
+    }
+    return map
+  }, [templates])
+
+  return {
+    templates,
+    templatesById,
+    loading,
+    error,
+    refresh,
+    createTemplate,
+    updateTemplate,
+    removeTemplate,
+  }
+}

--- a/toolkits/latency_sleuth/frontend/index.tsx
+++ b/toolkits/latency_sleuth/frontend/index.tsx
@@ -1,0 +1,81 @@
+import { getReactRuntime, getRouterRuntime } from './runtime'
+
+import ProbeDesigner from './components/ProbeDesigner'
+import JobLogViewer from './components/JobLogViewer'
+import LatencyHeatmapView from './components/LatencyHeatmap'
+
+const React = getReactRuntime()
+const Router = getRouterRuntime()
+const { NavLink, Navigate, Route, Routes } = Router
+
+const navItems = [
+  { label: 'Designer', path: '', icon: 'draw', exact: true },
+  { label: 'Job Logs', path: 'jobs', icon: 'receipt_long', exact: false },
+  { label: 'Heatmap', path: 'heatmap', icon: 'grid_view', exact: false },
+]
+
+const navStyle = {
+  wrapper: {
+    padding: '1.5rem',
+    display: 'grid',
+    gap: '1.25rem',
+    color: 'var(--color-text-primary)',
+  },
+  nav: {
+    display: 'flex',
+    gap: '0.75rem',
+    flexWrap: 'wrap',
+  },
+  navLink(active: boolean) {
+    return {
+      padding: '0.5rem 0.85rem',
+      borderRadius: 8,
+      border: '1px solid var(--color-border)',
+      textDecoration: 'none',
+      background: active ? 'var(--color-accent)' : 'transparent',
+      color: active ? 'var(--color-sidebar-item-active-text)' : 'var(--color-link)',
+      fontWeight: 600,
+      display: 'inline-flex',
+      alignItems: 'center',
+      gap: '0.5rem',
+    }
+  },
+}
+
+export default function LatencySleuthApp() {
+  return (
+    <div className="tk-card" style={navStyle.wrapper}>
+      <header>
+        <h2 style={{ margin: 0, display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+          <span className="material-symbols-outlined" aria-hidden>
+            speed
+          </span>
+          Latency Sleuth
+        </h2>
+        <p style={{ margin: '0.35rem 0 0', color: 'var(--color-text-secondary)' }}>
+          Synthetic probes purpose-built for latency investigations and SLA validation.
+        </p>
+      </header>
+
+      <nav style={navStyle.nav}>
+        {navItems.map((item) => (
+          <NavLink key={item.label} to={item.path} end={item.exact} style={({ isActive }) => navStyle.navLink(isActive)}>
+            <span className="material-symbols-outlined" aria-hidden>
+              {item.icon}
+            </span>
+            {item.label}
+          </NavLink>
+        ))}
+      </nav>
+
+      <section>
+        <Routes>
+          <Route index element={<ProbeDesigner />} />
+          <Route path="jobs" element={<JobLogViewer />} />
+          <Route path="heatmap" element={<LatencyHeatmapView />} />
+          <Route path="*" element={<Navigate to="." replace />} />
+        </Routes>
+      </section>
+    </div>
+  )
+}

--- a/toolkits/latency_sleuth/frontend/runtime.ts
+++ b/toolkits/latency_sleuth/frontend/runtime.ts
@@ -1,0 +1,43 @@
+import type * as ReactNamespace from 'react'
+import type * as ReactRouterDomNamespace from 'react-router-dom'
+
+export type ToolkitRuntime = {
+  react: typeof ReactNamespace
+  reactRouterDom: typeof ReactRouterDomNamespace
+  apiFetch: (path: string, options?: RequestInit & { json?: unknown }) => Promise<any>
+}
+
+declare global {
+  interface Window {
+    __SRE_TOOLKIT_RUNTIME?: ToolkitRuntime
+  }
+}
+
+export function getToolkitRuntime(): ToolkitRuntime {
+  if (typeof window === 'undefined' || !window.__SRE_TOOLKIT_RUNTIME) {
+    throw new Error('SRE Toolkit runtime not injected yet')
+  }
+  return window.__SRE_TOOLKIT_RUNTIME
+}
+
+export function getReactRuntime() {
+  return getToolkitRuntime().react
+}
+
+export function getRouterRuntime() {
+  return getToolkitRuntime().reactRouterDom
+}
+
+export function apiFetch<T = unknown>(path: string, options: RequestInit & { json?: unknown } = {}) {
+  const runtime = getToolkitRuntime()
+  const headers = new Headers(options.headers)
+  if (options.json !== undefined) {
+    headers.set('Content-Type', 'application/json')
+  }
+  const request: RequestInit = {
+    ...options,
+    headers,
+    body: options.json !== undefined ? JSON.stringify(options.json) : options.body,
+  }
+  return runtime.apiFetch(path, request) as Promise<T>
+}

--- a/toolkits/latency_sleuth/frontend/types.ts
+++ b/toolkits/latency_sleuth/frontend/types.ts
@@ -1,0 +1,76 @@
+export type NotificationChannel = 'slack' | 'pagerduty' | 'email' | 'webhook'
+export type NotificationThreshold = 'always' | 'breach' | 'recovery'
+
+export type NotificationRule = {
+  channel: NotificationChannel
+  target: string
+  threshold: NotificationThreshold
+}
+
+export type ProbeTemplate = {
+  id: string
+  name: string
+  description?: string | null
+  url: string
+  method: 'GET' | 'HEAD' | 'POST'
+  sla_ms: number
+  interval_seconds: number
+  notification_rules: NotificationRule[]
+  tags: string[]
+  created_at: string
+  updated_at: string
+}
+
+export type ProbeTemplateCreate = {
+  name: string
+  description?: string | null
+  url: string
+  method?: 'GET' | 'HEAD' | 'POST'
+  sla_ms: number
+  interval_seconds?: number
+  notification_rules?: NotificationRule[]
+  tags?: string[]
+}
+
+export type ProbeExecutionSample = {
+  attempt: number
+  timestamp: string
+  latency_ms: number
+  breach: boolean
+  message?: string | null
+}
+
+export type ProbeExecutionSummary = {
+  template_id: string
+  template_name: string
+  sla_ms: number
+  samples: ProbeExecutionSample[]
+  average_latency_ms: number
+  breach_count: number
+  met_sla: boolean
+  notified_channels: NotificationChannel[]
+}
+
+export type HeatmapCell = {
+  timestamp: string
+  latency_ms: number
+  breach: boolean
+}
+
+export type LatencyHeatmap = {
+  template_id: string
+  columns: number
+  rows: HeatmapCell[][]
+}
+
+export type JobRecord = {
+  id: string
+  status: string
+  progress: number
+  logs: { ts: string; message: string }[]
+  result?: unknown
+  error?: string | null
+  payload?: Record<string, unknown>
+  created_at: string
+  updated_at: string
+}

--- a/toolkits/latency_sleuth/frontend/vitest.config.mts
+++ b/toolkits/latency_sleuth/frontend/vitest.config.mts
@@ -1,0 +1,30 @@
+import { createRequire } from 'node:module'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(__dirname, '../../..')
+const frontendRoot = resolve(repoRoot, 'frontend')
+const nodeModules = resolve(frontendRoot, 'node_modules')
+
+const frontendRequire = createRequire(resolve(frontendRoot, 'package.json'))
+const { defineConfig } = frontendRequire('vitest/config')
+const reactPlugin = frontendRequire('@vitejs/plugin-react')
+const react = reactPlugin.default ?? reactPlugin
+
+export default defineConfig({
+  root: repoRoot,
+  plugins: [react()],
+  resolve: {
+    alias: {
+      react: resolve(nodeModules, 'react'),
+      'react-dom': resolve(nodeModules, 'react-dom'),
+      'react-dom/client': resolve(nodeModules, 'react-dom/client'),
+      'react-dom/test-utils': resolve(nodeModules, 'react-dom/test-utils'),
+    },
+  },
+  test: {
+    environment: 'node',
+    include: ['toolkits/latency_sleuth/frontend/**/*.test.tsx'],
+  },
+})

--- a/toolkits/latency_sleuth/tests/conftest.py
+++ b/toolkits/latency_sleuth/tests/conftest.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import os
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, Iterator, List
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+BACKEND_ROOT = ROOT / "backend"
+if str(ROOT) not in os.sys.path:
+    os.sys.path.insert(0, str(ROOT))
+if str(BACKEND_ROOT) not in os.sys.path:
+    os.sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.core import redis as redis_module
+from app.services import jobs as job_store
+from toolkits.latency_sleuth.backend import storage as storage_module
+
+
+class FakeRedis:
+    def __init__(self) -> None:
+        self._hashes: Dict[str, Dict[str, str]] = defaultdict(dict)
+        self._lists: Dict[str, List[str]] = defaultdict(list)
+
+    # Hash operations
+    def hset(self, name: str, key: str, value: str) -> None:
+        self._hashes[name][key] = value
+
+    def hget(self, name: str, key: str) -> str | None:
+        return self._hashes[name].get(key)
+
+    def hvals(self, name: str) -> List[str]:
+        return list(self._hashes[name].values())
+
+    def hdel(self, name: str, key: str) -> int:
+        if key in self._hashes[name]:
+            del self._hashes[name][key]
+            return 1
+        return 0
+
+    # List operations
+    def lpush(self, name: str, value: str) -> None:
+        self._lists[name].insert(0, value)
+
+    def lrange(self, name: str, start: int, stop: int) -> List[str]:
+        values = self._lists[name]
+        if stop == -1:
+            return values[start:]
+        return values[start : stop + 1]
+
+    def ltrim(self, name: str, start: int, stop: int) -> None:
+        values = self._lists[name]
+        self._lists[name] = values[start : stop + 1]
+
+    def delete(self, name: str) -> None:
+        self._hashes.pop(name, None)
+        self._lists.pop(name, None)
+
+    def scan_iter(self, pattern: str) -> Iterator[str]:
+        if pattern.endswith("*"):
+            prefix = pattern[:-1]
+            for key in list(self._lists.keys()):
+                if key.startswith(prefix):
+                    yield key
+        else:
+            if pattern in self._lists:
+                yield pattern
+
+    def flushall(self) -> None:
+        self._hashes.clear()
+        self._lists.clear()
+
+
+@pytest.fixture(autouse=True)
+def fake_redis(monkeypatch: pytest.MonkeyPatch) -> FakeRedis:
+    fake = FakeRedis()
+
+    monkeypatch.setattr(redis_module, "get_redis", lambda: fake)
+    monkeypatch.setattr(job_store, "get_redis", lambda: fake)
+    monkeypatch.setattr(storage_module, "get_redis", lambda: fake)
+
+    return fake

--- a/toolkits/latency_sleuth/tests/test_backend_routes.py
+++ b/toolkits/latency_sleuth/tests/test_backend_routes.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.services import jobs as job_store
+
+from toolkits.latency_sleuth.backend.app import router
+from toolkits.latency_sleuth.backend.models import ProbeTemplate
+from toolkits.latency_sleuth.backend.probes import execute_probe
+from toolkits.latency_sleuth.backend.storage import record_probe_result
+
+
+def create_client() -> TestClient:
+    app = FastAPI()
+    app.include_router(router, prefix="")
+    return TestClient(app)
+
+
+def _create_template(client: TestClient) -> dict:
+    response = client.post(
+        "/probe-templates",
+        json={
+            "name": "Checkout",
+            "url": "https://example.com/checkout",
+            "sla_ms": 450,
+            "method": "GET",
+            "interval_seconds": 120,
+            "notification_rules": [
+                {"channel": "slack", "target": "#alerts", "threshold": "breach"},
+            ],
+            "tags": ["service:checkout"],
+        },
+    )
+    assert response.status_code == 201
+    return response.json()
+
+
+def test_create_and_list_templates(fake_redis) -> None:
+    client = create_client()
+
+    created = _create_template(client)
+    assert created["name"] == "Checkout"
+    assert created["sla_ms"] == 450
+    assert created["notification_rules"][0]["channel"] == "slack"
+
+    listing = client.get("/probe-templates")
+    assert listing.status_code == 200
+    payload = listing.json()
+    assert len(payload) == 1
+    assert payload[0]["id"] == created["id"]
+
+
+def test_preview_endpoint_returns_summary(fake_redis) -> None:
+    client = create_client()
+    template = _create_template(client)
+
+    preview = client.post(
+        f"/probe-templates/{template['id']}/actions/preview",
+        json={"sample_size": 2, "latency_overrides": [480, 80]},
+    )
+    assert preview.status_code == 200
+    data = preview.json()
+    assert data["template_id"] == template["id"]
+    assert len(data["samples"]) == 2
+    assert data["breach_count"] == 1
+
+
+def test_run_endpoint_enqueues_job(monkeypatch, fake_redis) -> None:
+    client = create_client()
+    template = _create_template(client)
+
+    captured = {}
+
+    def fake_enqueue(toolkit: str, operation: str, payload: dict) -> dict:
+        captured["args"] = (toolkit, operation, payload)
+        return {"id": "job-123", "status": "queued", "logs": []}
+
+    monkeypatch.setattr("toolkits.latency_sleuth.backend.app.enqueue_job", fake_enqueue)
+
+    response = client.post(
+        f"/probe-templates/{template['id']}/actions/run",
+        json={"sample_size": 4},
+    )
+    assert response.status_code == 202
+    body = response.json()
+    assert body["job"]["id"] == "job-123"
+    assert captured["args"][0] == "latency-sleuth"
+    assert captured["args"][1] == "run_probe"
+    assert captured["args"][2]["sample_size"] == 4
+
+
+def test_heatmap_endpoint_returns_cells(fake_redis) -> None:
+    client = create_client()
+    template = _create_template(client)
+
+    template_model = ProbeTemplate.model_validate(template)
+    summary = execute_probe(template_model, sample_size=3, overrides=[100, 120, 90])
+    record_probe_result(summary)
+
+    response = client.get(f"/probe-templates/{template['id']}/heatmap")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["template_id"] == template["id"]
+    assert len(data["rows"]) >= 1
+
+
+def test_job_endpoints(fake_redis) -> None:
+    client = create_client()
+    template = _create_template(client)
+
+    job = job_store.create_job("latency-sleuth", "run_probe", {"template_id": template["id"]})
+
+    listing = client.get("/jobs")
+    assert listing.status_code == 200
+    jobs = listing.json()
+    assert any(item["id"] == job["id"] for item in jobs)
+
+    detail = client.get(f"/jobs/{job['id']}")
+    assert detail.status_code == 200
+    assert detail.json()["id"] == job["id"]

--- a/toolkits/latency_sleuth/tests/test_worker_tasks.py
+++ b/toolkits/latency_sleuth/tests/test_worker_tasks.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from app.services import jobs as job_store
+
+from toolkits.latency_sleuth.backend.models import ProbeTemplateCreate
+from toolkits.latency_sleuth.backend.storage import create_template, list_history
+from toolkits.latency_sleuth.worker.tasks import _handle_run_probe
+
+
+def _make_template() -> str:
+    template = create_template(
+        ProbeTemplateCreate(
+            name="API",
+            url="https://example.com/api",
+            sla_ms=200,
+            interval_seconds=120,
+            notification_rules=[{"channel": "email", "target": "ops@example.com", "threshold": "breach"}],
+            tags=["service:api"],
+        )
+    )
+    return template.id
+
+
+def test_handle_run_probe_success(fake_redis) -> None:
+    template_id = _make_template()
+    job = job_store.create_job(
+        "latency-sleuth",
+        "run_probe",
+        {"template_id": template_id, "sample_size": 2, "latency_overrides": [50, 220]},
+    )
+
+    result = _handle_run_probe(job)
+
+    assert result["status"] == "succeeded"
+    assert result["progress"] == 100
+    assert result["result"]["breach_count"] == 1
+
+    history = list_history(template_id)
+    assert len(history) == 1
+    assert history[0].summary.template_id == template_id
+
+
+def test_handle_run_probe_honours_cancellation(monkeypatch, fake_redis) -> None:
+    template_id = _make_template()
+    job = job_store.create_job(
+        "latency-sleuth",
+        "run_probe",
+        {"template_id": template_id, "sample_size": 3, "latency_overrides": [210, 180, 150]},
+    )
+
+    original_get_job = job_store.get_job
+    call_count = {"value": 0}
+
+    def fake_get_job(job_id: str):
+        record = original_get_job(job_id)
+        call_count["value"] += 1
+        if call_count["value"] == 2 and record:
+            job_store.mark_cancelling(record, "Operator requested cancellation")
+            record = original_get_job(job_id)
+        return record
+
+    monkeypatch.setattr(job_store, "get_job", fake_get_job)
+
+    result = _handle_run_probe(job)
+
+    assert result["status"] == "cancelled"
+
+    history = list_history(template_id)
+    assert history == []

--- a/toolkits/latency_sleuth/toolkit.json
+++ b/toolkits/latency_sleuth/toolkit.json
@@ -1,0 +1,28 @@
+{
+  "slug": "latency-sleuth",
+  "name": "Latency Sleuth",
+  "description": "Model web latency probes, tune SLAs, and visualise performance drift with synthetic checks.",
+  "version": "1.0.0",
+  "updated_at": "2024-10-01T00:00:00Z",
+  "base_path": "/toolkits/latency-sleuth",
+  "backend": {
+    "module": "backend.app",
+    "router_attr": "router"
+  },
+  "worker": {
+    "module": "worker.tasks",
+    "register_attr": "register"
+  },
+  "frontend": {
+    "entry": "frontend/dist/index.js",
+    "source_entry": "frontend/index.tsx"
+  },
+  "dashboard_cards": [
+    {
+      "title": "Synthetic Probes",
+      "body": "Author SLA-aware HTTP probes, stream live latency telemetry, and wire alerts to on-call tools.",
+      "link_text": "Launch",
+      "link_href": "/toolkits/latency-sleuth"
+    }
+  ]
+}

--- a/toolkits/latency_sleuth/worker/__init__.py
+++ b/toolkits/latency_sleuth/worker/__init__.py
@@ -1,0 +1,3 @@
+from .tasks import register
+
+__all__ = ["register"]

--- a/toolkits/latency_sleuth/worker/tasks.py
+++ b/toolkits/latency_sleuth/worker/tasks.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Iterable, List, Sequence
+
+from app.services import jobs as job_store
+
+from ..backend.probes import execute_probe
+from ..backend.storage import get_template, record_probe_result
+
+JobPayload = Dict[str, Any]
+JobRecord = Dict[str, Any]
+JobHandler = Callable[[JobRecord], JobRecord]
+
+
+def _normalise_overrides(payload: JobPayload) -> Sequence[float] | None:
+    overrides = payload.get("latency_overrides")
+    if overrides is None:
+        return None
+    if not isinstance(overrides, Iterable) or isinstance(overrides, (str, bytes)):
+        raise ValueError("latency_overrides must be a sequence of numbers")
+    result: List[float] = []
+    for item in overrides:
+        try:
+            result.append(float(item))
+        except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+            raise ValueError("latency_overrides must be numeric") from exc
+    return result
+
+
+def _handle_run_probe(job: JobRecord) -> JobRecord:
+    payload = job.get("payload", {})
+    template_id = payload.get("template_id")
+    if not template_id:
+        raise ValueError("template_id is required")
+
+    template = get_template(template_id)
+    if not template:
+        raise ValueError(f"Probe template {template_id} not found")
+
+    sample_size = payload.get("sample_size") or 3
+    try:
+        sample_size = int(sample_size)
+    except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+        raise ValueError("sample_size must be an integer") from exc
+    if sample_size <= 0:
+        raise ValueError("sample_size must be positive")
+
+    overrides = _normalise_overrides(payload)
+
+    job = job_store.append_log(job, f"Running latency probe '{template.name}' ({sample_size} samples)")
+
+    summary = execute_probe(template, sample_size=sample_size, overrides=overrides)
+
+    total_samples = max(len(summary.samples), 1)
+    for idx, sample in enumerate(summary.samples, start=1):
+        current = job_store.get_job(job["id"])
+        if current and current.get("status") == "cancelling":
+            return job_store.mark_cancelled(current, "Probe cancellation requested; stopping remaining samples")
+
+        job["progress"] = int(idx / total_samples * 100)
+        job = job_store.append_log(
+            job,
+            f"Attempt {sample.attempt}: {sample.latency_ms:.2f} ms — {'BREACH' if sample.breach else 'OK'}",
+        )
+        job_store.save_job(job)
+
+    record_probe_result(summary)
+
+    if summary.notified_channels:
+        channels = ", ".join(summary.notified_channels)
+        job = job_store.append_log(job, f"Notifications dispatched to: {channels}")
+
+    job["status"] = "succeeded"
+    job["progress"] = 100
+    job["result"] = summary.model_dump(mode="json")
+    job_store.save_job(job)
+    return job
+
+
+def register(celery_app, register_handler: Callable[[str, JobHandler], None]) -> None:  # noqa: D401
+    """Register worker handlers for the Latency Sleuth toolkit."""
+
+    register_handler("latency-sleuth.run_probe", _handle_run_probe)
+
+
+__all__ = ["register", "_handle_run_probe"]


### PR DESCRIPTION
## Summary
- add the optional latency-sleuth toolkit with FastAPI APIs, Redis storage helpers, and Celery worker integration
- deliver a self-contained React experience for probe design, job telemetry, and latency heatmaps plus operator docs
- introduce pytest and vitest coverage for toolkit routes, worker tasks, and hooks

## Testing
- pytest toolkits/latency_sleuth/tests
- npm --prefix frontend test -- --config ../toolkits/latency_sleuth/frontend/vitest.config.mts

------
https://chatgpt.com/codex/tasks/task_b_68ce5d817bec8328914f91ba728a3581