### PR TITLE
Add bundled toolbox health toolkit

### DIFF
--- a/toolkits/bundled/toolbox_health/BUILDING.md
+++ b/toolkits/bundled/toolbox_health/BUILDING.md
@@ -1,0 +1,26 @@
+# Building the Toolbox Health Toolkit
+
+1. Bundle the frontend so `frontend/dist/index.js` reflects the latest UI:
+
+   ```bash
+   cd frontend
+   npx --yes esbuild ../toolkits/bundled/toolbox_health/frontend/index.tsx \
+     --bundle \
+     --format=esm \
+     --platform=browser \
+     --outfile=../toolkits/bundled/toolbox_health/frontend/dist/index.js \
+     --external:react \
+     --external:react-dom \
+     --external:react-router-dom \
+     --loader:.ts=ts \
+     --loader:.tsx=tsx
+   ```
+
+2. Package the toolkit using the helper script:
+
+   ```bash
+   python ../../scripts/package_toolkit.py .
+   ```
+
+3. Upload the generated `toolbox-health_toolkit.zip` through **Administration → Toolkits** or via the `/toolkits/install` API.
+

--- a/toolkits/bundled/toolbox_health/backend/__init__.py
+++ b/toolkits/bundled/toolbox_health/backend/__init__.py
@@ -1,0 +1,2 @@
+"""Toolbox health toolkit backend package."""
+

--- a/toolkits/bundled/toolbox_health/backend/app.py
+++ b/toolkits/bundled/toolbox_health/backend/app.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from .health import build_health_summary, gather_component_health
+from .models import ComponentHealth, HealthSummary
+
+
+router = APIRouter(prefix="/health")
+
+
+@router.get("/components", response_model=list[ComponentHealth], summary="Health for each toolbox component")
+async def list_component_health() -> list[ComponentHealth]:
+    """Return the most recent health snapshot for the toolbox core services."""
+
+    return await gather_component_health()
+
+
+@router.get("/summary", response_model=HealthSummary, summary="Overall toolbox health summary")
+async def health_summary() -> HealthSummary:
+    """Aggregate component health into a single status payload."""
+
+    return await build_health_summary()
+

--- a/toolkits/bundled/toolbox_health/backend/dashboard.py
+++ b/toolkits/bundled/toolbox_health/backend/dashboard.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from .health import build_health_summary_sync
+from .models import HealthStatus
+
+
+_STATUS_LABELS = {
+    HealthStatus.HEALTHY: "Healthy",
+    HealthStatus.DEGRADED: "Degraded",
+    HealthStatus.DOWN: "Down",
+    HealthStatus.UNKNOWN: "Unknown",
+}
+
+
+def _format_component_metric(component) -> dict:
+    label = component.component.title()
+    status_label = _STATUS_LABELS.get(component.status, component.status.value.title())
+    latency = component.latency_ms
+    description = component.message
+    if latency is not None:
+        description = f"{description} (latency {latency:.0f} ms)"
+    return {
+        "label": f"{label} service",
+        "value": status_label,
+        "description": description,
+    }
+
+
+def build_context() -> dict:
+    summary = build_health_summary_sync()
+    metrics = [
+        {
+            "label": "Overall health",
+            "value": _STATUS_LABELS.get(summary.overall_status, summary.overall_status.value.title()),
+            "description": summary.notes,
+        }
+    ]
+    metrics.extend(_format_component_metric(component) for component in summary.components)
+    return {"metrics": metrics}
+

--- a/toolkits/bundled/toolbox_health/backend/health.py
+++ b/toolkits/bundled/toolbox_health/backend/health.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import asyncio
+import textwrap
+from datetime import datetime, timezone
+from time import perf_counter
+from typing import Iterable, List
+
+import httpx
+from sqlalchemy import text
+from sqlalchemy.exc import SQLAlchemyError
+
+from backend.app.config import settings
+from backend.app.db.session import SessionLocal
+from backend.app.worker_client import celery_app
+
+from .models import ComponentHealth, ComponentName, HealthStatus, HealthSummary
+
+
+_COMPONENT_ORDER: tuple[ComponentName, ...] = ("frontend", "backend", "worker")
+_STATUS_RANK = {
+    HealthStatus.HEALTHY: 0,
+    HealthStatus.UNKNOWN: 1,
+    HealthStatus.DEGRADED: 2,
+    HealthStatus.DOWN: 3,
+}
+
+
+def _short_error(exc: Exception) -> str:
+    message = str(exc).strip() or exc.__class__.__name__
+    return textwrap.shorten(message, width=160, placeholder="…")
+
+
+async def _check_backend() -> ComponentHealth:
+    started = perf_counter()
+    try:
+        async with SessionLocal() as session:
+            await session.execute(text("SELECT 1"))
+        latency = (perf_counter() - started) * 1000
+        return ComponentHealth(
+            component="backend",
+            status=HealthStatus.HEALTHY,
+            message="Database connectivity verified.",
+            latency_ms=round(latency, 2),
+        )
+    except SQLAlchemyError as exc:
+        return ComponentHealth(
+            component="backend",
+            status=HealthStatus.DOWN,
+            message=f"Database check failed: {_short_error(exc)}",
+        )
+    except Exception as exc:  # pragma: no cover - defensive guard
+        return ComponentHealth(
+            component="backend",
+            status=HealthStatus.DOWN,
+            message=f"Unhandled backend check error: {_short_error(exc)}",
+        )
+
+
+async def _check_worker(timeout: float = 2.0) -> ComponentHealth:
+    started = perf_counter()
+    try:
+        replies = await asyncio.to_thread(celery_app.control.ping, timeout=timeout)
+    except Exception as exc:
+        return ComponentHealth(
+            component="worker",
+            status=HealthStatus.DOWN,
+            message=f"Celery ping failed: {_short_error(exc)}",
+        )
+
+    latency = (perf_counter() - started) * 1000
+    reply_count = len(replies or [])
+    if reply_count == 0:
+        return ComponentHealth(
+            component="worker",
+            status=HealthStatus.DEGRADED,
+            message="No Celery workers responded within timeout.",
+            latency_ms=round(latency, 2),
+        )
+
+    worker_names = sorted(item for reply in replies for item in reply.keys())
+    detail = ", ".join(worker_names)
+    message = "1 worker responding" if reply_count == 1 else f"{reply_count} workers responding"
+    return ComponentHealth(
+        component="worker",
+        status=HealthStatus.HEALTHY,
+        message=f"{message}: {detail}",
+        latency_ms=round(latency, 2),
+        details={"workers": worker_names},
+    )
+
+
+async def _check_frontend() -> ComponentHealth:
+    base_url = settings.frontend_base_url
+    if not base_url:
+        return ComponentHealth(
+            component="frontend",
+            status=HealthStatus.HEALTHY,
+            message="No external frontend URL configured; assuming co-hosted UI.",
+        )
+
+    url = str(base_url)
+    started = perf_counter()
+    try:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(2.5)) as client:
+            response = await client.get(url, headers={"Accept": "text/html"})
+    except Exception as exc:
+        return ComponentHealth(
+            component="frontend",
+            status=HealthStatus.DOWN,
+            message=f"Request to frontend failed: {_short_error(exc)}",
+            details={"frontend_base_url": url},
+        )
+
+    latency = (perf_counter() - started) * 1000
+    status = HealthStatus.HEALTHY if response.status_code < 400 else HealthStatus.DEGRADED
+    message = (
+        f"Responded with HTTP {response.status_code}."
+        if status is HealthStatus.HEALTHY
+        else f"Returned HTTP {response.status_code}; investigate load balancer or app logs."
+    )
+    return ComponentHealth(
+        component="frontend",
+        status=status,
+        message=message,
+        latency_ms=round(latency, 2),
+        details={"frontend_base_url": url, "status_code": response.status_code},
+    )
+
+
+async def gather_component_health() -> List[ComponentHealth]:
+    checks = {
+        "frontend": _check_frontend(),
+        "backend": _check_backend(),
+        "worker": _check_worker(),
+    }
+    results = await asyncio.gather(*checks.values())
+    mapping = {result.component: result for result in results}
+    return [mapping[component] for component in _COMPONENT_ORDER if component in mapping]
+
+
+def _overall_status(components: Iterable[ComponentHealth]) -> HealthStatus:
+    worst = HealthStatus.HEALTHY
+    for component in components:
+        if _STATUS_RANK[component.status] > _STATUS_RANK[worst]:
+            worst = component.status
+    return worst
+
+
+def _summary_notes(status: HealthStatus) -> str:
+    if status is HealthStatus.HEALTHY:
+        return "All core services responded within acceptable thresholds."
+    if status is HealthStatus.DEGRADED:
+        return "At least one component responded slowly or returned a warning state."
+    if status is HealthStatus.DOWN:
+        return "Immediate attention required: one or more services failed health checks."
+    return "Component health is inconclusive; verify configuration manually."
+
+
+async def build_health_summary() -> HealthSummary:
+    components = await gather_component_health()
+    checked_at = max((component.checked_at for component in components), default=datetime.now(timezone.utc))
+    overall = _overall_status(components)
+    return HealthSummary(
+        overall_status=overall,
+        checked_at=checked_at,
+        components=components,
+        notes=_summary_notes(overall),
+    )
+
+
+def build_health_summary_sync() -> HealthSummary:
+    """Synchronous helper for dashboard context builders."""
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    if loop and loop.is_running():  # pragma: no cover - defensive guard
+        raise RuntimeError("build_health_summary_sync must not run inside an active event loop")
+
+    return asyncio.run(build_health_summary())
+

--- a/toolkits/bundled/toolbox_health/backend/models.py
+++ b/toolkits/bundled/toolbox_health/backend/models.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Dict, Literal
+
+from pydantic import BaseModel, Field
+
+
+class HealthStatus(str, Enum):
+    """Possible health states for toolbox components."""
+
+    HEALTHY = "healthy"
+    DEGRADED = "degraded"
+    DOWN = "down"
+    UNKNOWN = "unknown"
+
+
+ComponentName = Literal["frontend", "backend", "worker"]
+
+
+class ComponentHealth(BaseModel):
+    """Health payload for a single toolbox component."""
+
+    component: ComponentName
+    status: HealthStatus
+    message: str
+    checked_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    latency_ms: float | None = Field(default=None, description="Round-trip latency in milliseconds.")
+    details: Dict[str, Any] | None = Field(default=None, description="Extra diagnostic details.")
+
+
+class HealthSummary(BaseModel):
+    """Aggregated health information covering all toolbox components."""
+
+    overall_status: HealthStatus
+    checked_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    components: list[ComponentHealth]
+    notes: str | None = None
+

--- a/toolkits/bundled/toolbox_health/frontend/components/StatusIndicator.tsx
+++ b/toolkits/bundled/toolbox_health/frontend/components/StatusIndicator.tsx
@@ -1,0 +1,65 @@
+import type { ComponentStatus } from '../pages/types'
+
+const statusConfig: Record<
+  ComponentStatus,
+  { label: string; icon: string; color: string; background: string; textColor: string }
+> = {
+  healthy: {
+    label: 'Healthy',
+    icon: 'check_circle',
+    color: 'var(--color-success-border)',
+    background: 'var(--color-success-bg)',
+    textColor: 'var(--color-success-text)',
+  },
+  degraded: {
+    label: 'Degraded',
+    icon: 'error',
+    color: 'var(--color-warning-border)',
+    background: 'var(--color-warning-bg)',
+    textColor: 'var(--color-warning-text)',
+  },
+  down: {
+    label: 'Down',
+    icon: 'cancel',
+    color: 'var(--color-danger-border)',
+    background: 'var(--color-danger-bg)',
+    textColor: 'var(--color-danger-text)',
+  },
+  unknown: {
+    label: 'Unknown',
+    icon: 'help',
+    color: 'var(--color-border)',
+    background: 'var(--color-surface-alt)',
+    textColor: 'var(--color-text-secondary)',
+  },
+}
+
+export function getStatusConfig(status: ComponentStatus) {
+  return statusConfig[status] ?? statusConfig.unknown
+}
+
+export default function StatusIndicator({ status }: { status: ComponentStatus }) {
+  const config = getStatusConfig(status)
+  return (
+    <span
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '0.35rem',
+        padding: '0.2rem 0.55rem',
+        borderRadius: 999,
+        border: `1px solid ${config.color}`,
+        background: config.background,
+        color: config.textColor,
+        fontWeight: 600,
+        fontSize: '0.85rem',
+      }}
+    >
+      <span className="material-symbols-outlined" aria-hidden style={{ fontSize: '1rem', lineHeight: 1 }}>
+        {config.icon}
+      </span>
+      {config.label}
+    </span>
+  )
+}
+

--- a/toolkits/bundled/toolbox_health/frontend/dist/index.js
+++ b/toolkits/bundled/toolbox_health/frontend/dist/index.js
@@ -1,0 +1,241 @@
+// ../toolkits/bundled/toolbox_health/frontend/runtime.ts
+function getToolkitRuntime() {
+  if (typeof window === "undefined" || !window.__SRE_TOOLKIT_RUNTIME) {
+    throw new Error("SRE Toolkit runtime not injected yet");
+  }
+  return window.__SRE_TOOLKIT_RUNTIME;
+}
+function getReactRuntime() {
+  return getToolkitRuntime().react;
+}
+function getReactRouterRuntime() {
+  return getToolkitRuntime().reactRouterDom;
+}
+function apiFetch(path, options) {
+  return getToolkitRuntime().apiFetch(path, options);
+}
+
+// ../toolkits/bundled/toolbox_health/frontend/components/StatusIndicator.tsx
+var statusConfig = {
+  healthy: {
+    label: "Healthy",
+    icon: "check_circle",
+    color: "var(--color-success-border)",
+    background: "var(--color-success-bg)",
+    textColor: "var(--color-success-text)"
+  },
+  degraded: {
+    label: "Degraded",
+    icon: "error",
+    color: "var(--color-warning-border)",
+    background: "var(--color-warning-bg)",
+    textColor: "var(--color-warning-text)"
+  },
+  down: {
+    label: "Down",
+    icon: "cancel",
+    color: "var(--color-danger-border)",
+    background: "var(--color-danger-bg)",
+    textColor: "var(--color-danger-text)"
+  },
+  unknown: {
+    label: "Unknown",
+    icon: "help",
+    color: "var(--color-border)",
+    background: "var(--color-surface-alt)",
+    textColor: "var(--color-text-secondary)"
+  }
+};
+function getStatusConfig(status) {
+  return statusConfig[status] ?? statusConfig.unknown;
+}
+function StatusIndicator({ status }) {
+  const config = getStatusConfig(status);
+  return /* @__PURE__ */ React.createElement(
+    "span",
+    {
+      style: {
+        display: "inline-flex",
+        alignItems: "center",
+        gap: "0.35rem",
+        padding: "0.2rem 0.55rem",
+        borderRadius: 999,
+        border: `1px solid ${config.color}`,
+        background: config.background,
+        color: config.textColor,
+        fontWeight: 600,
+        fontSize: "0.85rem"
+      }
+    },
+    /* @__PURE__ */ React.createElement("span", { className: "material-symbols-outlined", "aria-hidden": true, style: { fontSize: "1rem", lineHeight: 1 } }, config.icon),
+    config.label
+  );
+}
+
+// ../toolkits/bundled/toolbox_health/frontend/pages/OverviewPage.tsx
+var React2 = getReactRuntime();
+var componentDescriptions = {
+  frontend: "Renders the administrative UI and serves static assets.",
+  backend: "Provides the REST API, database access, and authentication.",
+  worker: "Processes asynchronous jobs, schedules automation, and handles long-running tasks."
+};
+function formatTimestamp(value) {
+  if (!value) {
+    return "Unknown";
+  }
+  try {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return value;
+    }
+    return date.toLocaleString();
+  } catch (error) {
+    return value;
+  }
+}
+function formatLatency(latency) {
+  if (latency === null || typeof latency === "undefined") {
+    return "\u2014";
+  }
+  return `${Math.round(latency)} ms`;
+}
+function HealthCard({ summary }) {
+  const overallConfig = getStatusConfig(summary.overall_status);
+  return /* @__PURE__ */ React2.createElement(
+    "section",
+    {
+      className: "tk-card",
+      style: {
+        display: "grid",
+        gap: "1rem",
+        padding: "1.5rem",
+        border: `1px solid ${overallConfig.color}`
+      }
+    },
+    /* @__PURE__ */ React2.createElement("div", { style: { display: "flex", flexDirection: "column", gap: "0.5rem" } }, /* @__PURE__ */ React2.createElement("div", { style: { display: "flex", alignItems: "center", justifyContent: "space-between", flexWrap: "wrap" } }, /* @__PURE__ */ React2.createElement(StatusIndicator, { status: summary.overall_status }), /* @__PURE__ */ React2.createElement("span", { style: { color: "var(--color-text-secondary)", fontSize: "0.85rem" } }, "Last checked ", formatTimestamp(summary.checked_at))), /* @__PURE__ */ React2.createElement("h4", { style: { margin: 0 } }, "Toolbox core services"), /* @__PURE__ */ React2.createElement("p", { style: { margin: 0, color: "var(--color-text-secondary)" } }, summary.notes))
+  );
+}
+function ComponentGrid({ components }) {
+  return /* @__PURE__ */ React2.createElement("section", { className: "tk-card", style: { padding: "1.5rem", display: "grid", gap: "1rem" } }, /* @__PURE__ */ React2.createElement("header", { style: { display: "flex", alignItems: "center", justifyContent: "space-between", flexWrap: "wrap", gap: "0.5rem" } }, /* @__PURE__ */ React2.createElement("h4", { style: { margin: 0, display: "flex", alignItems: "center", gap: "0.4rem" } }, /* @__PURE__ */ React2.createElement("span", { className: "material-symbols-outlined", style: { fontSize: "1.1rem", color: "var(--color-link)" }, "aria-hidden": true }, "lan"), "Component details"), /* @__PURE__ */ React2.createElement("span", { style: { color: "var(--color-text-secondary)", fontSize: "0.85rem" } }, "Click refresh to capture a new snapshot.")), /* @__PURE__ */ React2.createElement("div", { style: { display: "grid", gap: "1rem", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))" } }, components.map((component) => {
+    const description = componentDescriptions[component.component] ?? "Monitored service.";
+    return /* @__PURE__ */ React2.createElement(
+      "article",
+      {
+        key: component.component,
+        style: {
+          border: "1px solid var(--color-border)",
+          borderRadius: 12,
+          padding: "1rem",
+          display: "grid",
+          gap: "0.75rem",
+          background: "var(--color-surface)"
+        }
+      },
+      /* @__PURE__ */ React2.createElement("header", { style: { display: "grid", gap: "0.4rem" } }, /* @__PURE__ */ React2.createElement("div", { style: { display: "flex", justifyContent: "space-between", alignItems: "center" } }, /* @__PURE__ */ React2.createElement("strong", { style: { fontSize: "1rem" } }, component.component.toUpperCase()), /* @__PURE__ */ React2.createElement(StatusIndicator, { status: component.status })), /* @__PURE__ */ React2.createElement("p", { style: { margin: 0, color: "var(--color-text-secondary)" } }, description)),
+      /* @__PURE__ */ React2.createElement("dl", { style: { margin: 0, display: "grid", gap: "0.45rem" } }, /* @__PURE__ */ React2.createElement("div", { style: { display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: "0.5rem" } }, /* @__PURE__ */ React2.createElement("dt", { style: { margin: 0, color: "var(--color-text-secondary)" } }, "Message"), /* @__PURE__ */ React2.createElement("dd", { style: { margin: 0, textAlign: "right", color: "var(--color-text-primary)" } }, component.message)), /* @__PURE__ */ React2.createElement("div", { style: { display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: "0.5rem" } }, /* @__PURE__ */ React2.createElement("dt", { style: { margin: 0, color: "var(--color-text-secondary)" } }, "Latency"), /* @__PURE__ */ React2.createElement("dd", { style: { margin: 0, textAlign: "right" } }, formatLatency(component.latency_ms))), /* @__PURE__ */ React2.createElement("div", { style: { display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: "0.5rem" } }, /* @__PURE__ */ React2.createElement("dt", { style: { margin: 0, color: "var(--color-text-secondary)" } }, "Checked"), /* @__PURE__ */ React2.createElement("dd", { style: { margin: 0, textAlign: "right" } }, formatTimestamp(component.checked_at))))
+    );
+  })));
+}
+function OverviewPage() {
+  const { useCallback, useEffect, useMemo, useState } = React2;
+  const [summary, setSummary] = useState(null);
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [refreshIndex, setRefreshIndex] = useState(0);
+  const fetchSummary = useCallback(async (signal) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await apiFetch("/toolkits/toolbox-health/health/summary", {
+        signal,
+        cache: "no-store"
+      });
+      setSummary(response);
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") {
+        return;
+      }
+      setError(err instanceof Error ? err.message : "Failed to load health summary.");
+    } finally {
+      setLoading(false);
+    }
+  }, [setSummary]);
+  useEffect(() => {
+    const controller = new AbortController();
+    fetchSummary(controller.signal).catch(() => {
+      setError("Failed to load health summary.");
+    });
+    return () => controller.abort();
+  }, [fetchSummary, refreshIndex]);
+  const refresh = useCallback(() => {
+    setRefreshIndex((index) => index + 1);
+  }, []);
+  const components = useMemo(() => summary?.components ?? [], [summary]);
+  return /* @__PURE__ */ React2.createElement("div", { style: { display: "grid", gap: "1.5rem" } }, /* @__PURE__ */ React2.createElement("div", { style: { display: "flex", justifyContent: "flex-end" } }, /* @__PURE__ */ React2.createElement(
+    "button",
+    {
+      type: "button",
+      className: "tk-button tk-button--secondary",
+      onClick: refresh,
+      disabled: loading,
+      style: { display: "inline-flex", alignItems: "center", gap: "0.4rem" }
+    },
+    /* @__PURE__ */ React2.createElement("span", { className: "material-symbols-outlined", "aria-hidden": true }, loading ? "hourglass_top" : "refresh"),
+    loading ? "Refreshing\u2026" : "Refresh"
+  )), error && /* @__PURE__ */ React2.createElement(
+    "div",
+    {
+      role: "alert",
+      className: "tk-card",
+      style: {
+        border: "1px solid var(--color-danger-border)",
+        background: "var(--color-danger-bg)",
+        color: "var(--color-danger-text)",
+        padding: "1rem"
+      }
+    },
+    /* @__PURE__ */ React2.createElement("strong", { style: { display: "flex", alignItems: "center", gap: "0.4rem" } }, /* @__PURE__ */ React2.createElement("span", { className: "material-symbols-outlined", "aria-hidden": true }, "error"), "Unable to update health status"),
+    /* @__PURE__ */ React2.createElement("span", { style: { marginTop: "0.35rem", display: "block" } }, error)
+  ), summary && /* @__PURE__ */ React2.createElement(HealthCard, { summary }), components.length > 0 && /* @__PURE__ */ React2.createElement(ComponentGrid, { components }), !loading && !summary && !error && /* @__PURE__ */ React2.createElement("p", { style: { color: "var(--color-text-secondary)" } }, "No health data available."));
+}
+
+// ../toolkits/bundled/toolbox_health/frontend/index.tsx
+var React3 = getReactRuntime();
+var ReactRouterDom = getReactRouterRuntime();
+var { NavLink, Navigate, Route, Routes } = ReactRouterDom;
+var layoutStyles = {
+  wrapper: {
+    padding: "1.5rem",
+    display: "grid",
+    gap: "1.5rem",
+    color: "var(--color-text-primary)"
+  },
+  nav: {
+    display: "flex",
+    gap: "0.5rem",
+    flexWrap: "wrap"
+  },
+  navLink: (active) => ({
+    padding: "0.5rem 0.9rem",
+    borderRadius: 8,
+    border: "1px solid var(--color-border)",
+    background: active ? "var(--color-accent)" : "transparent",
+    color: active ? "var(--color-sidebar-item-active-text)" : "var(--color-link)",
+    fontWeight: 600,
+    textDecoration: "none",
+    display: "inline-flex",
+    alignItems: "center",
+    gap: "0.4rem"
+  })
+};
+var iconStyle = {
+  fontSize: "1.15rem",
+  lineHeight: 1,
+  color: "var(--color-link)"
+};
+function ToolboxHealthToolkitLayout() {
+  return /* @__PURE__ */ React3.createElement("div", { className: "tk-card", style: layoutStyles.wrapper }, /* @__PURE__ */ React3.createElement("header", null, /* @__PURE__ */ React3.createElement("h3", { style: { margin: 0, display: "flex", alignItems: "center", gap: "0.45rem" } }, /* @__PURE__ */ React3.createElement("span", { className: "material-symbols-outlined", style: iconStyle, "aria-hidden": true }, "stethoscope"), "Toolbox Health"), /* @__PURE__ */ React3.createElement("p", { style: { margin: "0.3rem 0 0", color: "var(--color-text-secondary)" } }, "Monitor the vitality of the Toolbox frontend, backend, and worker services.")), /* @__PURE__ */ React3.createElement("nav", { style: layoutStyles.nav, "aria-label": "Toolbox health views" }, /* @__PURE__ */ React3.createElement(NavLink, { end: true, to: "", style: ({ isActive }) => layoutStyles.navLink(isActive) }, /* @__PURE__ */ React3.createElement("span", { className: "material-symbols-outlined", style: iconStyle, "aria-hidden": true }, "dashboard"), "Overview")), /* @__PURE__ */ React3.createElement("section", null, /* @__PURE__ */ React3.createElement(Routes, null, /* @__PURE__ */ React3.createElement(Route, { index: true, element: /* @__PURE__ */ React3.createElement(OverviewPage, null) }), /* @__PURE__ */ React3.createElement(Route, { path: "*", element: /* @__PURE__ */ React3.createElement(Navigate, { to: ".", replace: true }) }))));
+}
+export {
+  ToolboxHealthToolkitLayout as default
+};

--- a/toolkits/bundled/toolbox_health/frontend/index.tsx
+++ b/toolkits/bundled/toolbox_health/frontend/index.tsx
@@ -1,0 +1,75 @@
+import type { CSSProperties } from 'react'
+
+import { getReactRuntime, getReactRouterRuntime } from './runtime'
+import OverviewPage from './pages/OverviewPage'
+
+const React = getReactRuntime()
+const ReactRouterDom = getReactRouterRuntime()
+const { NavLink, Navigate, Route, Routes } = ReactRouterDom
+
+const layoutStyles = {
+  wrapper: {
+    padding: '1.5rem',
+    display: 'grid',
+    gap: '1.5rem',
+    color: 'var(--color-text-primary)',
+  },
+  nav: {
+    display: 'flex',
+    gap: '0.5rem',
+    flexWrap: 'wrap',
+  },
+  navLink: (active: boolean) => ({
+    padding: '0.5rem 0.9rem',
+    borderRadius: 8,
+    border: '1px solid var(--color-border)',
+    background: active ? 'var(--color-accent)' : 'transparent',
+    color: active ? 'var(--color-sidebar-item-active-text)' : 'var(--color-link)',
+    fontWeight: 600,
+    textDecoration: 'none',
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '0.4rem',
+  }),
+} satisfies Record<string, CSSProperties | ((active: boolean) => CSSProperties)>
+
+const iconStyle: CSSProperties = {
+  fontSize: '1.15rem',
+  lineHeight: 1,
+  color: 'var(--color-link)',
+}
+
+export default function ToolboxHealthToolkitLayout() {
+  return (
+    <div className="tk-card" style={layoutStyles.wrapper}>
+      <header>
+        <h3 style={{ margin: 0, display: 'flex', alignItems: 'center', gap: '0.45rem' }}>
+          <span className="material-symbols-outlined" style={iconStyle} aria-hidden>
+            stethoscope
+          </span>
+          Toolbox Health
+        </h3>
+        <p style={{ margin: '0.3rem 0 0', color: 'var(--color-text-secondary)' }}>
+          Monitor the vitality of the Toolbox frontend, backend, and worker services.
+        </p>
+      </header>
+
+      <nav style={layoutStyles.nav} aria-label="Toolbox health views">
+        <NavLink end to="" style={({ isActive }) => layoutStyles.navLink(isActive)}>
+          <span className="material-symbols-outlined" style={iconStyle} aria-hidden>
+            dashboard
+          </span>
+          Overview
+        </NavLink>
+      </nav>
+
+      <section>
+        <Routes>
+          <Route index element={<OverviewPage />} />
+          <Route path="*" element={<Navigate to="." replace />} />
+        </Routes>
+      </section>
+    </div>
+  )
+}
+

--- a/toolkits/bundled/toolbox_health/frontend/pages/OverviewPage.tsx
+++ b/toolkits/bundled/toolbox_health/frontend/pages/OverviewPage.tsx
@@ -1,0 +1,210 @@
+import { apiFetch, getReactRuntime } from '../runtime'
+import StatusIndicator, { getStatusConfig } from '../components/StatusIndicator'
+import type { ComponentHealth, HealthSummary } from './types'
+
+const React = getReactRuntime()
+
+const componentDescriptions: Record<string, string> = {
+  frontend: 'Renders the administrative UI and serves static assets.',
+  backend: 'Provides the REST API, database access, and authentication.',
+  worker: 'Processes asynchronous jobs, schedules automation, and handles long-running tasks.',
+}
+
+function formatTimestamp(value: string | null | undefined) {
+  if (!value) {
+    return 'Unknown'
+  }
+  try {
+    const date = new Date(value)
+    if (Number.isNaN(date.getTime())) {
+      return value
+    }
+    return date.toLocaleString()
+  } catch (error) {
+    return value
+  }
+}
+
+function formatLatency(latency?: number | null) {
+  if (latency === null || typeof latency === 'undefined') {
+    return '—'
+  }
+  return `${Math.round(latency)} ms`
+}
+
+function HealthCard({ summary }: { summary: HealthSummary }) {
+  const overallConfig = getStatusConfig(summary.overall_status)
+
+  return (
+    <section
+      className="tk-card"
+      style={{
+        display: 'grid',
+        gap: '1rem',
+        padding: '1.5rem',
+        border: `1px solid ${overallConfig.color}`,
+      }}
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexWrap: 'wrap' }}>
+          <StatusIndicator status={summary.overall_status} />
+          <span style={{ color: 'var(--color-text-secondary)', fontSize: '0.85rem' }}>
+            Last checked {formatTimestamp(summary.checked_at)}
+          </span>
+        </div>
+        <h4 style={{ margin: 0 }}>Toolbox core services</h4>
+        <p style={{ margin: 0, color: 'var(--color-text-secondary)' }}>{summary.notes}</p>
+      </div>
+    </section>
+  )
+}
+
+function ComponentGrid({ components }: { components: ComponentHealth[] }) {
+  return (
+    <section className="tk-card" style={{ padding: '1.5rem', display: 'grid', gap: '1rem' }}>
+      <header style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexWrap: 'wrap', gap: '0.5rem' }}>
+        <h4 style={{ margin: 0, display: 'flex', alignItems: 'center', gap: '0.4rem' }}>
+          <span className="material-symbols-outlined" style={{ fontSize: '1.1rem', color: 'var(--color-link)' }} aria-hidden>
+            lan
+          </span>
+          Component details
+        </h4>
+        <span style={{ color: 'var(--color-text-secondary)', fontSize: '0.85rem' }}>
+          Click refresh to capture a new snapshot.
+        </span>
+      </header>
+
+      <div style={{ display: 'grid', gap: '1rem', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))' }}>
+        {components.map((component) => {
+          const description = componentDescriptions[component.component] ?? 'Monitored service.'
+          return (
+            <article
+              key={component.component}
+              style={{
+                border: '1px solid var(--color-border)',
+                borderRadius: 12,
+                padding: '1rem',
+                display: 'grid',
+                gap: '0.75rem',
+                background: 'var(--color-surface)',
+              }}
+            >
+              <header style={{ display: 'grid', gap: '0.4rem' }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                  <strong style={{ fontSize: '1rem' }}>{component.component.toUpperCase()}</strong>
+                  <StatusIndicator status={component.status} />
+                </div>
+                <p style={{ margin: 0, color: 'var(--color-text-secondary)' }}>{description}</p>
+              </header>
+
+              <dl style={{ margin: 0, display: 'grid', gap: '0.45rem' }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: '0.5rem' }}>
+                  <dt style={{ margin: 0, color: 'var(--color-text-secondary)' }}>Message</dt>
+                  <dd style={{ margin: 0, textAlign: 'right', color: 'var(--color-text-primary)' }}>{component.message}</dd>
+                </div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: '0.5rem' }}>
+                  <dt style={{ margin: 0, color: 'var(--color-text-secondary)' }}>Latency</dt>
+                  <dd style={{ margin: 0, textAlign: 'right' }}>{formatLatency(component.latency_ms)}</dd>
+                </div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: '0.5rem' }}>
+                  <dt style={{ margin: 0, color: 'var(--color-text-secondary)' }}>Checked</dt>
+                  <dd style={{ margin: 0, textAlign: 'right' }}>{formatTimestamp(component.checked_at)}</dd>
+                </div>
+              </dl>
+            </article>
+          )
+        })}
+      </div>
+    </section>
+  )
+}
+
+export default function OverviewPage() {
+  const { useCallback, useEffect, useMemo, useState } = React
+  const [summary, setSummary] = useState<HealthSummary | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState<boolean>(false)
+  const [refreshIndex, setRefreshIndex] = useState(0)
+
+  const fetchSummary = useCallback(async (signal?: AbortSignal) => {
+    setLoading(true)
+    setError(null)
+    try {
+      const response = await apiFetch<HealthSummary>('/toolkits/toolbox-health/health/summary', {
+        signal,
+        cache: 'no-store',
+      })
+      setSummary(response)
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') {
+        return
+      }
+      setError(err instanceof Error ? err.message : 'Failed to load health summary.')
+    } finally {
+      setLoading(false)
+    }
+  }, [setSummary])
+
+  useEffect(() => {
+    const controller = new AbortController()
+    fetchSummary(controller.signal).catch(() => {
+      setError('Failed to load health summary.')
+    })
+    return () => controller.abort()
+  }, [fetchSummary, refreshIndex])
+
+  const refresh = useCallback(() => {
+    setRefreshIndex((index) => index + 1)
+  }, [])
+
+  const components = useMemo(() => summary?.components ?? [], [summary])
+
+  return (
+    <div style={{ display: 'grid', gap: '1.5rem' }}>
+      <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+        <button
+          type="button"
+          className="tk-button tk-button--secondary"
+          onClick={refresh}
+          disabled={loading}
+          style={{ display: 'inline-flex', alignItems: 'center', gap: '0.4rem' }}
+        >
+          <span className="material-symbols-outlined" aria-hidden>
+            {loading ? 'hourglass_top' : 'refresh'}
+          </span>
+          {loading ? 'Refreshing…' : 'Refresh'}
+        </button>
+      </div>
+
+      {error && (
+        <div
+          role="alert"
+          className="tk-card"
+          style={{
+            border: '1px solid var(--color-danger-border)',
+            background: 'var(--color-danger-bg)',
+            color: 'var(--color-danger-text)',
+            padding: '1rem',
+          }}
+        >
+          <strong style={{ display: 'flex', alignItems: 'center', gap: '0.4rem' }}>
+            <span className="material-symbols-outlined" aria-hidden>
+              error
+            </span>
+            Unable to update health status
+          </strong>
+          <span style={{ marginTop: '0.35rem', display: 'block' }}>{error}</span>
+        </div>
+      )}
+
+      {summary && <HealthCard summary={summary} />}
+
+      {components.length > 0 && <ComponentGrid components={components} />}
+
+      {!loading && !summary && !error && (
+        <p style={{ color: 'var(--color-text-secondary)' }}>No health data available.</p>
+      )}
+    </div>
+  )
+}
+

--- a/toolkits/bundled/toolbox_health/frontend/pages/types.ts
+++ b/toolkits/bundled/toolbox_health/frontend/pages/types.ts
@@ -1,0 +1,19 @@
+export type ComponentStatus = 'healthy' | 'degraded' | 'down' | 'unknown'
+
+export type ComponentName = 'frontend' | 'backend' | 'worker'
+
+export type ComponentHealth = {
+  component: ComponentName
+  status: ComponentStatus
+  message: string
+  checked_at: string
+  latency_ms?: number | null
+}
+
+export type HealthSummary = {
+  overall_status: ComponentStatus
+  checked_at: string
+  components: ComponentHealth[]
+  notes?: string | null
+}
+

--- a/toolkits/bundled/toolbox_health/frontend/runtime.ts
+++ b/toolkits/bundled/toolbox_health/frontend/runtime.ts
@@ -1,0 +1,34 @@
+import type * as ReactNamespace from 'react'
+import type * as ReactRouterDomNamespace from 'react-router-dom'
+
+export type ToolkitRuntime = {
+  react: typeof ReactNamespace
+  reactRouterDom: typeof ReactRouterDomNamespace
+  apiFetch: (path: string, options?: Record<string, unknown>) => Promise<unknown>
+}
+
+declare global {
+  interface Window {
+    __SRE_TOOLKIT_RUNTIME?: ToolkitRuntime
+  }
+}
+
+export function getToolkitRuntime(): ToolkitRuntime {
+  if (typeof window === 'undefined' || !window.__SRE_TOOLKIT_RUNTIME) {
+    throw new Error('SRE Toolkit runtime not injected yet')
+  }
+  return window.__SRE_TOOLKIT_RUNTIME
+}
+
+export function getReactRuntime() {
+  return getToolkitRuntime().react
+}
+
+export function getReactRouterRuntime() {
+  return getToolkitRuntime().reactRouterDom
+}
+
+export function apiFetch<T = unknown>(path: string, options?: Record<string, unknown>) {
+  return getToolkitRuntime().apiFetch(path, options) as Promise<T>
+}
+

--- a/toolkits/bundled/toolbox_health/toolkit.json
+++ b/toolkits/bundled/toolbox_health/toolkit.json
@@ -1,0 +1,32 @@
+{
+  "slug": "toolbox-health",
+  "name": "Toolbox Health",
+  "description": "Monitor the Toolbox frontend, backend, and worker services.",
+  "base_path": "/toolkits/toolbox-health",
+  "backend": {
+    "module": "backend.app",
+    "router_attr": "router"
+  },
+  "worker": {
+    "module": "worker.tasks",
+    "register_attr": "register"
+  },
+  "dashboard": {
+    "module": "backend.dashboard",
+    "callable": "build_context"
+  },
+  "frontend": {
+    "entry": "frontend/dist/index.js",
+    "source_entry": "frontend/index.tsx"
+  },
+  "dashboard_cards": [
+    {
+      "title": "Toolbox Health",
+      "body": "View the real-time status of the core Toolbox services.",
+      "link_text": "Open",
+      "link_href": "/toolkits/toolbox-health",
+      "icon": "stethoscope"
+    }
+  ]
+}
+

--- a/toolkits/bundled/toolbox_health/worker/tasks.py
+++ b/toolkits/bundled/toolbox_health/worker/tasks.py
@@ -1,0 +1,24 @@
+"""Worker registration for the Toolbox Health toolkit."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Optional
+
+
+def register(
+    celery_app: Any,
+    register_handler: Optional[Callable[[str, Callable[[Dict[str, Any]], Dict[str, Any]]], None]] = None,
+    **_: Any,
+) -> None:
+    """Expose a no-op register hook so the loader can import the worker module.
+
+    The health toolkit runs checks on-demand and does not schedule background jobs,
+    but providing this callable keeps the loader happy and leaves room for future
+    asynchronous probes if needed.
+    """
+
+    return None
+
+
+__all__ = ["register"]
+


### PR DESCRIPTION
## Summary
- add a bundled toolbox health toolkit that monitors the core frontend, backend, and worker services
- implement backend aggregation, dashboard context, and worker registration hooks for health checks
- build a user-friendly overview UI and document bundling steps for the new toolkit

## Testing
- python toolkits/scripts/package_toolkit.py toolkits/bundled/toolbox_health

------
https://chatgpt.com/codex/tasks/task_b_68cf4415f5ac832890ec01024343db4f