### PR TITLE
Improve toolbox shell layout and admin styling

### DIFF
--- a/frontend/src/AppShell.css
+++ b/frontend/src/AppShell.css
@@ -1,0 +1,328 @@
+.app-shell {
+  display: grid;
+  grid-template-columns: minmax(236px, 264px) minmax(0, 1fr);
+  min-height: 100vh;
+  background: var(--color-app-bg);
+  color: var(--color-text-primary);
+  font-family: Inter, system-ui, sans-serif;
+}
+
+.app-shell__sidebar {
+  position: sticky;
+  top: 0;
+  align-self: start;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+  padding: 1.4rem 1.1rem 1.6rem;
+  box-sizing: border-box;
+  background: var(--color-sidebar-bg);
+  color: var(--color-sidebar-text);
+}
+
+.app-shell__branding {
+  display: flex;
+  gap: 0.85rem;
+  align-items: center;
+}
+
+.app-shell__badge {
+  width: 46px;
+  height: 46px;
+  border-radius: 14px;
+  background: var(--color-sidebar-badge-bg, rgba(255, 255, 255, 0.08));
+  border: 1px solid var(--color-sidebar-badge-border, rgba(255, 255, 255, 0.12));
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  font-size: 1rem;
+  letter-spacing: 0.08em;
+  color: inherit;
+}
+
+.app-shell__branding-text {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.app-shell__branding-text h1 {
+  margin: 0;
+  font-size: 1.32rem;
+  font-weight: 600;
+}
+
+.app-shell__branding-text p {
+  margin: 0;
+  font-size: 0.86rem;
+  color: var(--color-sidebar-muted);
+  opacity: 0.8;
+}
+
+.app-shell__nav {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  overflow-y: auto;
+  padding-right: 0.35rem;
+  margin-right: -0.35rem;
+  min-height: 0;
+}
+
+.app-shell__nav section + section {
+  margin-top: 0.35rem;
+}
+
+.app-shell__section {
+  display: grid;
+  gap: 0.6rem;
+  padding: 0.7rem 0.85rem 0.82rem;
+  border-radius: 13px;
+  border: 1px solid var(--color-sidebar-panel-border, rgba(255, 255, 255, 0.05));
+  background: var(--color-sidebar-panel-bg, rgba(255, 255, 255, 0.03));
+  box-shadow: 0 16px 28px -30px rgba(0, 0, 0, 0.6);
+  box-sizing: border-box;
+}
+
+.app-shell__section-header {
+  display: grid;
+  gap: 0.28rem;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-sidebar-muted);
+}
+
+.app-shell__section-header span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-weight: 600;
+}
+
+.app-shell__section-description {
+  margin: 0;
+  font-size: 0.72rem;
+  color: var(--color-sidebar-muted);
+  letter-spacing: 0;
+  text-transform: none;
+  opacity: 0.78;
+}
+
+.app-shell__section-body {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.app-shell__toolkit-list {
+  display: grid;
+  gap: 0.3rem;
+  margin-top: 0.3rem;
+  padding-left: 0.2rem;
+}
+
+.app-shell__empty-state {
+  margin: 0.15rem 0 0;
+  font-size: 0.78rem;
+  color: var(--color-text-muted);
+}
+
+.app-shell__nav-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  border-radius: 10px;
+  border: 1px solid transparent;
+  text-decoration: none;
+  transition: background 0.18s ease, box-shadow 0.2s ease, color 0.18s ease, border 0.2s ease;
+  font-size: 0.86rem;
+  font-weight: 500;
+  box-sizing: border-box;
+}
+
+.app-shell__nav-link-content {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.app-shell__nav-link--standard {
+  padding: 0.55rem 0.85rem;
+  background: var(--color-sidebar-item-bg);
+  color: var(--color-sidebar-item-text);
+}
+
+.app-shell__nav-link--standard.is-active {
+  background: var(--color-sidebar-item-active-bg);
+  color: var(--color-sidebar-item-active-text);
+  font-weight: 600;
+  box-shadow: 0 6px 20px -16px rgba(0, 0, 0, 0.7);
+}
+
+.app-shell__nav-link--prominent {
+  padding: 0.65rem 1rem;
+  border-radius: 12px;
+  background: var(--color-sidebar-item-bg);
+  color: var(--color-sidebar-text);
+  font-weight: 550;
+  box-shadow: 0 10px 22px -24px rgba(0, 0, 0, 0.8);
+}
+
+.app-shell__nav-link--prominent.is-active {
+  background: var(--color-sidebar-button-active-bg);
+  color: var(--color-sidebar-item-active-text);
+  border-color: var(--color-outline);
+  box-shadow: 0 0 0 1px var(--color-outline);
+  font-weight: 600;
+}
+
+.app-shell__nav-link--button {
+  padding: 0.65rem 1rem;
+  border-radius: 12px;
+  justify-content: center;
+  background: var(--color-sidebar-button-bg);
+  color: var(--color-sidebar-button-text);
+  font-weight: 600;
+  text-align: center;
+  box-shadow: 0 12px 26px -24px rgba(0, 0, 0, 0.75);
+}
+
+.app-shell__nav-link--button.is-active {
+  background: var(--color-sidebar-button-active-bg);
+  color: var(--color-sidebar-button-active-text);
+  box-shadow: 0 10px 25px -12px var(--color-outline);
+}
+
+.app-shell__footer {
+  display: grid;
+  gap: 0.65rem;
+  margin-top: auto;
+  padding-top: 0.55rem;
+}
+
+.app-shell__footer-controls {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.app-shell__theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  border-radius: 12px;
+  border: 1px solid transparent;
+  padding: 0.6rem 0.9rem;
+  background: var(--color-sidebar-button-bg);
+  color: var(--color-sidebar-button-text);
+  cursor: pointer;
+  transition: background 0.18s ease, box-shadow 0.2s ease;
+  font-size: 0.85rem;
+  font-weight: 600;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.app-shell__theme-toggle:hover {
+  background: var(--color-sidebar-button-active-bg);
+  color: var(--color-sidebar-button-active-text);
+}
+
+.app-shell__user-card {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 0.9rem;
+  border-radius: 12px;
+  border: 1px solid var(--color-sidebar-panel-border, rgba(255, 255, 255, 0.06));
+  background: var(--color-sidebar-panel-bg, rgba(255, 255, 255, 0.04));
+  box-shadow: 0 12px 24px -24px rgba(0, 0, 0, 0.55);
+  box-sizing: border-box;
+}
+
+.app-shell__user-initials {
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: var(--color-sidebar-text);
+  background: var(--color-sidebar-avatar-bg, rgba(255, 255, 255, 0.09));
+  border: 1px solid var(--color-sidebar-badge-border, rgba(255, 255, 255, 0.12));
+}
+
+.app-shell__user-details {
+  display: grid;
+  gap: 0.2rem;
+  flex: 1;
+}
+
+.app-shell__user-name {
+  font-weight: 600;
+  color: var(--color-sidebar-text);
+}
+
+.app-shell__user-detail {
+  font-size: 0.78rem;
+  color: var(--color-sidebar-muted);
+}
+
+.app-shell__icon-button {
+  border: 1px solid transparent;
+  border-radius: 10px;
+  background: var(--color-sidebar-button-bg);
+  color: var(--color-sidebar-button-text);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.45rem 0.65rem;
+  cursor: pointer;
+  transition: background 0.18s ease;
+}
+
+.app-shell__icon-button:hover {
+  background: var(--color-sidebar-button-active-bg);
+  color: var(--color-sidebar-button-active-text);
+}
+
+.app-shell__content {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  padding: 2.2rem clamp(2rem, 4vw, 3.25rem);
+  color: var(--color-text-primary);
+  box-sizing: border-box;
+  min-height: 100vh;
+}
+
+.app-shell__content > header h2 {
+  margin: 0;
+  color: var(--color-text-primary);
+}
+
+.app-shell__content > header p {
+  margin: 0.25rem 0 0;
+  color: var(--color-text-secondary);
+}
+
+.app-shell__api-meta {
+  font-size: 0.78rem;
+  color: var(--color-sidebar-muted);
+  opacity: 0.75;
+}
+
+.app-shell__placeholder {
+  background: var(--color-surface);
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: var(--color-shadow);
+  border: 1px solid var(--color-border);
+}
+
+.app-shell__placeholder p {
+  color: var(--color-text-secondary);
+}

--- a/frontend/src/AppShell.tsx
+++ b/frontend/src/AppShell.tsx
@@ -8,6 +8,7 @@ import { useTheme } from './ThemeContext'
 import { ToolkitRecord, useToolkits } from './ToolkitContext'
 import toolkitPrimitivesStyles from './toolkitPrimitives.css?inline'
 import { useAuth } from './AuthContext'
+import './AppShell.css'
 import AdminToolkitsPage from './pages/AdminToolkitsPage'
 import AdminUsersPage from './pages/AdminUsersPage'
 import AdminSecurityPage from './pages/AdminSecurityPage'
@@ -130,117 +131,6 @@ async function resolveToolkitComponent(toolkit: ToolkitRecord): Promise<React.Co
   return modulePromiseCache.get(key) as Promise<React.ComponentType>
 }
 
-const layoutStyles = {
-  app: {
-    display: 'grid',
-    gridTemplateColumns: '264px 1fr',
-    minHeight: '100vh',
-    height: '100vh',
-    fontFamily: 'Inter, system-ui, sans-serif',
-    background: 'var(--color-app-bg)',
-    color: 'var(--color-text-primary)',
-    overflow: 'hidden' as const,
-  } as React.CSSProperties,
-  sidebar: {
-    background: 'var(--color-sidebar-bg)',
-    color: 'var(--color-sidebar-text)',
-    padding: '1.2rem 1.05rem 1.7rem',
-    display: 'grid',
-    gridTemplateRows: 'auto 1fr auto',
-    gap: '1rem',
-    minHeight: '100vh',
-    height: '100vh',
-    boxSizing: 'border-box' as const,
-    overflowY: 'hidden' as const,
-    overflowX: 'visible' as const,
-    width: 'fit-content',
-  },
-  navLinkVariants: {
-    standard: (active: boolean) => ({
-      padding: '0.55rem 0.85rem',
-      borderRadius: 10,
-      color: active ? 'var(--color-sidebar-item-active-text)' : 'var(--color-sidebar-item-text)',
-      background: active ? 'var(--color-sidebar-item-active-bg)' : 'var(--color-sidebar-item-bg)',
-      fontWeight: active ? 600 : 500,
-      textDecoration: 'none',
-      transition: 'background 0.15s ease, box-shadow 0.2s ease',
-      fontSize: '0.85rem',
-      display: 'flex',
-      alignItems: 'center',
-      gap: '0.5rem',
-      width: '100%',
-      border: '1px solid transparent',
-      boxShadow: active ? '0 6px 20px -16px rgba(0, 0, 0, 0.7)' : 'none',
-      boxSizing: 'border-box' as const,
-    }),
-    prominent: (active: boolean) => ({
-      padding: '0.6rem 1rem',
-      borderRadius: 12,
-      color: active ? 'var(--color-sidebar-item-active-text)' : 'var(--color-sidebar-text)',
-      background: active ? 'var(--color-sidebar-button-active-bg)' : 'var(--color-sidebar-item-bg)',
-      fontWeight: active ? 600 : 550,
-      textDecoration: 'none',
-      transition: 'background 0.15s ease, box-shadow 0.2s ease',
-      fontSize: '0.9rem',
-      boxShadow: active ? '0 0 0 1px var(--color-outline)' : '0 10px 22px -24px rgba(0,0,0,0.8)',
-      display: 'flex',
-      alignItems: 'center',
-      gap: '0.55rem',
-      width: '100%',
-      border: active ? '1px solid var(--color-outline)' : '1px solid transparent',
-      boxSizing: 'border-box' as const,
-    }),
-    button: (active: boolean) => ({
-      padding: '0.65rem 1rem',
-      borderRadius: 12,
-      color: active ? 'var(--color-sidebar-button-active-text)' : 'var(--color-sidebar-button-text)',
-      background: active ? 'var(--color-sidebar-button-active-bg)' : 'var(--color-sidebar-button-bg)',
-      fontWeight: 600,
-      textDecoration: 'none',
-      transition: 'background 0.15s ease, box-shadow 0.2s ease',
-      fontSize: '0.85rem',
-      textAlign: 'center' as const,
-      boxShadow: active ? '0 10px 25px -12px var(--color-outline)' : '0 12px 26px -24px rgba(0,0,0,0.75)',
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      gap: '0.45rem',
-      width: '100%',
-      border: '1px solid transparent',
-      boxSizing: 'border-box' as const,
-    }),
-  } as Record<'standard' | 'prominent' | 'button', (active: boolean) => React.CSSProperties>,
-  content: {
-    padding: '2rem 3rem',
-    display: 'flex',
-    flexDirection: 'column' as const,
-    gap: '2rem',
-    color: 'var(--color-text-primary)',
-    height: '100vh',
-    boxSizing: 'border-box' as const,
-    overflowY: 'auto' as const,
-    overflowX: 'hidden' as const,
-  },
-}
-
-const themeToggleStyle: React.CSSProperties = {
-  display: 'inline-flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  gap: '0.45rem',
-  borderRadius: 12,
-  border: '1px solid transparent',
-  background: 'var(--color-sidebar-button-bg)',
-  color: 'var(--color-sidebar-button-text)',
-  padding: '0.6rem 0.9rem',
-  cursor: 'pointer',
-  transition: 'background 0.15s ease, box-shadow 0.2s ease',
-  fontSize: '0.85rem',
-  fontWeight: 600,
-  width: '100%',
-  boxSizing: 'border-box' as const,
-}
-
 export default function AppShell() {
   const { toolkits, loading } = useToolkits()
   const { toggleTheme, isDark } = useTheme()
@@ -254,21 +144,17 @@ export default function AppShell() {
   const canViewSecurity = hasRole('system.admin')
 
   return (
-    <div style={layoutStyles.app}>
-      <aside style={layoutStyles.sidebar}>
-        <div style={sidebarHeaderStyle}>
-          <div>
-            <div style={badgeStyle}>SRE</div>
-          </div>
-          <div>
-            <h1 style={{ fontSize: '1.35rem', margin: 0, fontWeight: 600 }}>SRE Toolbox</h1>
-            <p style={{ margin: '0.3rem 0 0', opacity: 0.75, fontSize: '0.88rem', color: 'var(--color-sidebar-muted)' }}>
-              Modular operations cockpit
-            </p>
+    <div className="app-shell">
+      <aside className="app-shell__sidebar">
+        <div className="app-shell__branding">
+          <div className="app-shell__badge">SRE</div>
+          <div className="app-shell__branding-text">
+            <h1>SRE Toolbox</h1>
+            <p>Modular operations cockpit</p>
           </div>
         </div>
 
-        <nav style={sidebarNavArea}>
+        <nav className="app-shell__nav" aria-label="Toolbox navigation">
           <SidebarSection title="Workspace" icon="dashboard" description="Monitor and oversee workloads">
             <SidebarLink to="/" label="Dashboard" icon="space_dashboard" end />
             <SidebarLink to="/jobs" label="Jobs" icon="work_history" />
@@ -276,13 +162,11 @@ export default function AppShell() {
 
           <SidebarSection title="Toolkits" icon="apps" description="Installed modules and experiences">
             {toolkits.length > 0 && <SidebarLink to="/toolkits" label="All toolkits" icon="grid_view" variant="prominent" />}
-            <div style={toolkitListStyle}>
+            <div className="app-shell__toolkit-list">
               {enabledToolkits.map((toolkit) => (
                 <SidebarLink key={toolkit.slug} to={toolkit.base_path} label={toolkit.name} icon="extension" />
               ))}
-              {enabledToolkits.length === 0 && !loading && (
-                <p style={{ margin: '0.15rem 0 0', fontSize: '0.78rem', color: 'var(--color-text-muted)' }}>No toolkits enabled.</p>
-              )}
+              {enabledToolkits.length === 0 && !loading && <p className="app-shell__empty-state">No toolkits enabled.</p>}
             </div>
           </SidebarSection>
 
@@ -300,34 +184,30 @@ export default function AppShell() {
           )}
         </nav>
 
-        <div style={sidebarFooterArea}>
+        <div className="app-shell__footer">
           {user && <SidebarUserCard user={user} onLogout={logout} />}
-          <div style={footerControlsStyle}>
+          <div className="app-shell__footer-controls">
             <button
               type="button"
               onClick={toggleTheme}
-              style={themeToggleStyle}
+              className="app-shell__theme-toggle"
               title={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
               value={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
               aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
             >
-              <MaterialIcon name={isDark ? 'dark_mode' : 'light_mode'} style={{ color: 'inherit', fontSize: '1.4rem' }} />
+              <MaterialIcon name={isDark ? 'dark_mode' : 'light_mode'} style={{ color: 'inherit', fontSize: '1.35rem' }} />
               <span>{isDark ? 'Dark' : 'Light'} mode</span>
             </button>
             <SidebarLink to="/documentation" label="Documentation" icon="menu_book" variant="button" />
           </div>
-          <div style={{ fontSize: '0.78rem', opacity: 0.75, color: 'var(--color-sidebar-muted)' }}>
-            API base: {API_BASE_URL || 'N/A'}
-          </div>
+          <div className="app-shell__api-meta">API base: {API_BASE_URL || 'N/A'}</div>
         </div>
       </aside>
 
-      <div style={layoutStyles.content}>
+      <div className="app-shell__content">
         <header>
-          <h2 style={{ margin: 0, color: 'var(--color-text-primary)' }}>Operations Overview</h2>
-          <p style={{ margin: '0.25rem 0 0', color: 'var(--color-text-secondary)' }}>
-            Monitor jobs, manage toolkits, and validate automations.
-          </p>
+          <h2>Operations Overview</h2>
+          <p>Monitor jobs, manage toolkits, and validate automations.</p>
         </header>
 
         <main>
@@ -416,10 +296,14 @@ function SidebarLink({
   end?: boolean
   variant?: 'standard' | 'prominent' | 'button'
 }) {
-  const styleFn = layoutStyles.navLinkVariants[variant]
+  const baseClass = `app-shell__nav-link app-shell__nav-link--${variant}`
   return (
-    <NavLink to={to} end={end} style={({ isActive }) => styleFn(isActive)}>
-      <span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.45rem' }}>
+    <NavLink
+      to={to}
+      end={end}
+      className={({ isActive }) => [baseClass, isActive ? 'is-active' : ''].filter(Boolean).join(' ')}
+    >
+      <span className="app-shell__nav-link-content">
         {icon && <MaterialIcon name={icon} style={{ color: 'inherit' }} />}
         <span>{label}</span>
       </span>
@@ -435,13 +319,18 @@ function SidebarUserCard({ user, onLogout }: { user: AuthenticatedUser; onLogout
   const initial = displayName.charAt(0).toUpperCase()
 
   return (
-    <div style={sidebarUserCardStyle}>
-      <div style={sidebarUserAvatarStyle} aria-hidden>{initial}</div>
-      <div style={{ display: 'grid', gap: '0.2rem', flex: 1 }}>
-        <span style={{ fontWeight: 600, color: 'var(--color-sidebar-text)' }}>{displayName}</span>
-        <span style={{ fontSize: '0.78rem', color: 'var(--color-sidebar-muted)' }}>{detail}</span>
+    <div className="app-shell__user-card">
+      <div className="app-shell__user-initials" aria-hidden>{initial}</div>
+      <div className="app-shell__user-details">
+        <span className="app-shell__user-name">{displayName}</span>
+        <span className="app-shell__user-detail">{detail}</span>
       </div>
-      <button type="button" onClick={() => onLogout()} style={sidebarUserButtonStyle}>
+      <button
+        type="button"
+        onClick={() => onLogout()}
+        className="app-shell__icon-button"
+        aria-label="Sign out"
+      >
         <MaterialIcon name="logout" style={{ fontSize: '1.1rem' }} />
       </button>
     </div>
@@ -460,15 +349,15 @@ function SidebarSection({
   children: React.ReactNode
 }) {
   return (
-    <section style={sidebarSectionStyle}>
-      <header style={sidebarSectionHeaderStyle}>
-        <span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.45rem', fontWeight: 600 }}>
+    <section className="app-shell__section">
+      <header className="app-shell__section-header">
+        <span>
           {icon && <MaterialIcon name={icon} style={{ color: 'var(--color-sidebar-muted)' }} />}
           <span>{title}</span>
         </span>
-        {description && <p style={sidebarSectionDescriptionStyle}>{description}</p>}
+        {description && <p className="app-shell__section-description">{description}</p>}
       </header>
-      <div style={{ display: 'grid', gap: '0.4rem' }}>{children}</div>
+      <div className="app-shell__section-body">{children}</div>
     </section>
   )
 }
@@ -493,17 +382,9 @@ function DynamicToolkitRouter() {
 
 function GenericToolkitPlaceholder({ toolkit, message }: { toolkit: ToolkitRecord; message?: string }) {
   return (
-    <div
-      style={{
-        background: 'var(--color-surface)',
-        borderRadius: 12,
-        padding: '1.5rem',
-        boxShadow: 'var(--color-shadow)',
-        border: '1px solid var(--color-border)',
-      }}
-    >
+    <div className="app-shell__placeholder">
       <h3 style={{ marginTop: 0 }}>{toolkit.name}</h3>
-      <p style={{ color: 'var(--color-text-secondary)' }}>{toolkit.description || 'Toolkit metadata registered. Awaiting implementation.'}</p>
+      <p>{toolkit.description || 'Toolkit metadata registered. Awaiting implementation.'}</p>
       {message ? (
         <p style={{ marginTop: '1rem', fontSize: '0.9rem', color: 'var(--color-text-secondary)' }}>{message}</p>
       ) : (
@@ -589,126 +470,3 @@ function ToolkitLoadingOverlay({ name }: { name: string }) {
   )
 }
 
-
-const sidebarFooterArea: React.CSSProperties = {
-  display: 'grid',
-  gap: '0.65rem',
-  marginTop: 'auto',
-  paddingTop: '0.55rem',
-  paddingBottom: '0.1rem',
-}
-
-const sidebarHeaderStyle: React.CSSProperties = {
-  display: 'grid',
-  gridTemplateColumns: 'auto 1fr',
-  gap: '0.85rem',
-  alignItems: 'center',
-}
-
-const sidebarNavArea: React.CSSProperties = {
-  display: 'contents',
-  gap: '0.95rem',
-  flex: 1,
-  overflowY: 'auto' as const,
-  overflowX: 'hidden' as const,
-  paddingRight: '0.3rem',
-  marginRight: '-0.3rem',
-  paddingBottom: '0.45rem',
-  minHeight: 0,
-}
-
-const badgeStyle: React.CSSProperties = {
-  width: 46,
-  height: 46,
-  borderRadius: 14,
-  background: 'var(--color-sidebar-badge-bg, rgba(255, 255, 255, 0.08))',
-  border: '1px solid var(--color-sidebar-badge-border, rgba(255, 255, 255, 0.12))',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  fontWeight: 700,
-  fontSize: '1rem',
-  letterSpacing: '0.08em',
-  color: 'var(--color-sidebar-text)',
-}
-
-const toolkitListStyle: React.CSSProperties = {
-  display: 'grid',
-  gap: '0.3rem',
-  marginTop: '0.35rem',
-  paddingLeft: '0.2rem',
-}
-
-const footerControlsStyle: React.CSSProperties = {
-  display: 'grid',
-  gap: '0.55rem',
-}
-
-const sidebarSectionStyle: React.CSSProperties = {
-  display: 'grid',
-  gap: '0.55rem',
-  padding: '0.68rem 0.85rem 0.82rem',
-  borderRadius: 13,
-  border: '1px solid var(--color-sidebar-panel-border, rgba(255, 255, 255, 0.05))',
-  background: 'var(--color-sidebar-panel-bg, rgba(255, 255, 255, 0.03))',
-  boxShadow: '0 16px 28px -30px rgba(0,0,0,0.6)',
-  boxSizing: 'border-box' as const,
-}
-
-const sidebarSectionHeaderStyle: React.CSSProperties = {
-  display: 'grid',
-  gap: '0.25rem',
-  fontSize: '0.8rem',
-  textTransform: 'uppercase',
-  letterSpacing: '0.08em',
-  color: 'var(--color-sidebar-muted)',
-}
-
-const sidebarSectionDescriptionStyle: React.CSSProperties = {
-  margin: 0,
-  fontSize: '0.72rem',
-  color: 'var(--color-sidebar-muted)',
-  textTransform: 'none',
-  letterSpacing: 0,
-  opacity: 0.78,
-}
-
-const sidebarUserCardStyle: React.CSSProperties = {
-  display: 'flex',
-  alignItems: 'center',
-  gap: '0.75rem',
-  padding: '0.75rem 0.9rem',
-  borderRadius: 12,
-  border: '1px solid var(--color-sidebar-panel-border, rgba(255, 255, 255, 0.06))',
-  background: 'var(--color-sidebar-panel-bg, rgba(255, 255, 255, 0.04))',
-  boxShadow: '0 12px 24px -24px rgba(0,0,0,0.55)',
-  boxSizing: 'border-box' as const,
-}
-
-const sidebarUserAvatarStyle: React.CSSProperties = {
-  width: 40,
-  height: 40,
-  borderRadius: 12,
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  fontWeight: 700,
-  fontSize: '0.95rem',
-  color: 'var(--color-sidebar-text)',
-  background: 'var(--color-sidebar-avatar-bg, rgba(255, 255, 255, 0.09))',
-  border: '1px solid var(--color-sidebar-badge-border, rgba(255, 255, 255, 0.12))',
-}
-
-const sidebarUserButtonStyle: React.CSSProperties = {
-  border: '1px solid transparent',
-  borderRadius: 10,
-  background: 'var(--color-sidebar-button-bg)',
-  color: 'var(--color-sidebar-button-text)',
-  display: 'inline-flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  padding: '0.45rem 0.65rem',
-  cursor: 'pointer',
-  transition: 'background 0.15s ease, box-shadow 0.2s ease',
-  boxSizing: 'border-box' as const,
-}

--- a/frontend/src/pages/AdminToolkitsPage.css
+++ b/frontend/src/pages/AdminToolkitsPage.css
@@ -1,0 +1,134 @@
+.admin-toolkits {
+  background: var(--color-surface);
+  border-radius: 12px;
+  box-shadow: var(--color-shadow);
+  border: 1px solid var(--color-border);
+  padding: 1.5rem;
+  display: grid;
+  gap: 1.4rem;
+}
+
+.admin-toolkits__section {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.admin-toolkits__helper {
+  margin: 0.25rem 0 0;
+  color: var(--color-text-secondary);
+  font-size: 0.9rem;
+}
+
+.admin-toolkits__docs {
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  padding: 1rem;
+  background: var(--color-surface-alt);
+  display: grid;
+  gap: 0.6rem;
+}
+
+.admin-toolkits__docs-intro {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--color-text-primary);
+}
+
+.admin-toolkits__docs ul {
+  margin: 0.75rem 0 0;
+  padding-left: 1.25rem;
+  color: var(--color-text-primary);
+  font-size: 0.9rem;
+}
+
+.admin-toolkits__docs p {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: 0.85rem;
+}
+
+.admin-toolkits__docs code {
+  font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 0.85rem;
+}
+
+.admin-toolkits__field {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+}
+
+.admin-toolkits__list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.admin-toolkits__item {
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  padding: 0.95rem 1.1rem;
+  background: var(--color-surface-alt);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.admin-toolkits__item-details {
+  display: grid;
+  gap: 0.35rem;
+  flex: 1 1 220px;
+}
+
+.admin-toolkits__item-description {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+}
+
+.admin-toolkits__item-meta {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+}
+
+.admin-toolkits__item-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.admin-toolkits__icon-button {
+  background: transparent;
+  border: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: color 0.18s ease, opacity 0.18s ease;
+}
+
+.admin-toolkits__icon-button.is-active {
+  color: var(--color-accent);
+}
+
+.admin-toolkits__icon-button--danger {
+  color: var(--color-danger-border);
+}
+
+.admin-toolkits__icon-button:disabled {
+  cursor: wait;
+  opacity: 0.6;
+}
+
+.admin-toolkits__form {
+  display: grid;
+  gap: 0.75rem;
+  max-width: 420px;
+}
+
+.admin-toolkits__empty {
+  color: var(--color-text-muted);
+}

--- a/frontend/src/pages/AdminToolkitsPage.tsx
+++ b/frontend/src/pages/AdminToolkitsPage.tsx
@@ -4,6 +4,7 @@ import { apiFetch } from '../api'
 import { useAuth } from '../AuthContext'
 import { MaterialIcon } from '../components/MaterialIcon'
 import { ToolkitRecord, useToolkits } from '../ToolkitContext'
+import './AdminToolkitsPage.css'
 
 type ToolkitDocs = {
   overview?: string
@@ -13,19 +14,9 @@ type ToolkitDocs = {
   dashboard?: string
 }
 
-const cardStyle: React.CSSProperties = {
-  background: 'var(--color-surface)',
-  borderRadius: 12,
-  boxShadow: 'var(--color-shadow)',
-  border: '1px solid var(--color-border)',
-  padding: '1.5rem',
-  display: 'grid',
-  gap: '1.25rem',
-}
-
 const Field = ({ label, children }: { label: string; children: React.ReactNode }) => (
-  <label style={{ display: 'grid', gap: '0.3rem', fontSize: '0.9rem' }}>
-    {label}
+  <label className="admin-toolkits__field">
+    <span>{label}</span>
     {children}
   </label>
 )
@@ -72,7 +63,7 @@ export default function AdminToolkitsPage() {
   }
 
   return (
-    <div style={cardStyle}>
+    <div className="admin-toolkits">
       <header>
         <h3 style={{ margin: 0, display: 'flex', alignItems: 'center', gap: '0.5rem', color: 'var(--color-text-primary)' }}>
           <MaterialIcon name="engineering" style={{ color: 'var(--color-link)' }} />
@@ -84,31 +75,23 @@ export default function AdminToolkitsPage() {
       </header>
 
       {docs && (
-        <section style={{ border: '1px solid var(--color-border)', borderRadius: 10, padding: '1rem', background: 'var(--color-surface-alt)' }}>
+        <section className="admin-toolkits__docs">
           <h4 style={{ margin: '0 0 0.5rem', display: 'flex', alignItems: 'center', gap: '0.4rem' }}>
             <MaterialIcon name="lightbulb" style={{ color: 'var(--color-warning-text)' }} />
             Getting started
           </h4>
-          {docs.overview && (
-            <p style={{ margin: 0, fontSize: '0.9rem', color: 'var(--color-text-primary)' }}>{docs.overview}</p>
-          )}
+          {docs.overview && <p className="admin-toolkits__docs-intro">{docs.overview}</p>}
           {docs.bundle_format?.contents && (
-            <ul style={{ margin: '0.75rem 0 0', paddingLeft: '1.25rem', color: 'var(--color-text-primary)', fontSize: '0.9rem' }}>
+            <ul>
               {docs.bundle_format.contents.map((item) => (
                 <li key={item}>{item}</li>
               ))}
             </ul>
           )}
-          {docs.upload?.post_install && (
-            <p style={{ margin: '0.75rem 0 0', fontSize: '0.85rem', color: 'var(--color-text-secondary)' }}>{docs.upload.post_install}</p>
-          )}
-          {docs.job_queue?.handlers && (
-            <p style={{ margin: '0.35rem 0 0', fontSize: '0.85rem', color: 'var(--color-text-secondary)' }}>{docs.job_queue.handlers}</p>
-          )}
-          {docs.dashboard && (
-            <p style={{ margin: '0.35rem 0 0', fontSize: '0.85rem', color: 'var(--color-text-secondary)' }}>{docs.dashboard}</p>
-          )}
-          <p style={{ margin: '0.75rem 0 0', fontSize: '0.85rem', color: 'var(--color-text-secondary)' }}>
+          {docs.upload?.post_install && <p>{docs.upload.post_install}</p>}
+          {docs.job_queue?.handlers && <p>{docs.job_queue.handlers}</p>}
+          {docs.dashboard && <p>{docs.dashboard}</p>}
+          <p>
             Upload bundles via <code>/toolkits/install</code> or the form below. After staging, enable the toolkit; SRE Toolbox will auto-load its
             backend routes, worker tasks, and dashboard contributions.
           </p>
@@ -117,39 +100,32 @@ export default function AdminToolkitsPage() {
 
       {error && <p style={{ color: 'var(--color-danger-border)' }}>{error}</p>}
 
-      <section>
+      <section className="admin-toolkits__section">
         <h4 style={{ marginTop: 0, display: 'flex', alignItems: 'center', gap: '0.4rem' }}>
           <MaterialIcon name="extension" style={{ color: 'var(--color-link)' }} />
           Installed toolkits
         </h4>
-        <div style={{ display: 'grid', gap: '0.75rem' }}>
-          {toolkits.length === 0 && <p style={{ color: 'var(--color-text-muted)' }}>No toolkits registered yet.</p>}
+        <div className="admin-toolkits__list">
+          {toolkits.length === 0 && <p className="admin-toolkits__empty">No toolkits registered yet.</p>}
           {toolkits.map((toolkit) => (
-            <div key={toolkit.slug} style={toolkitCardStyle}>
-              <div style={{ display: 'grid', gap: '0.35rem' }}>
+            <div key={toolkit.slug} className="admin-toolkits__item">
+              <div className="admin-toolkits__item-details">
                 <strong>{toolkit.name}</strong>
-                <div style={{ fontSize: '0.85rem', color: 'var(--color-text-secondary)' }}>{toolkit.description}</div>
-                <div style={{ fontSize: '0.75rem', color: 'var(--color-text-muted)' }}>
-                  Slug: {toolkit.slug} · Path: {toolkit.base_path}
-                  {toolkit.origin !== 'builtin' ? ' · Custom upload' : ' · Built-in'}
-                </div>
+                <div className="admin-toolkits__item-description">{toolkit.description}</div>
+                <div className="admin-toolkits__item-meta">Slug: {toolkit.slug} · Path: {toolkit.base_path}
+                  {toolkit.origin !== 'builtin' ? ' · Custom upload' : ' · Built-in'}</div>
               </div>
-              <div style={{ display: 'flex', gap: '0.75rem', alignItems: 'center' }}>
+              <div className="admin-toolkits__item-actions">
                 <button
                   type="button"
                   onClick={() => toggleToolkit(toolkit)}
                   disabled={busySlug === toolkit.slug}
-                  style={{
-                    display: 'inline-flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    width: 38,
-                    height: 38,
-                    border: '0px',
-                    background: 'transparent',
-                    color: toolkit.enabled ? 'var(--color-accent)' : 'var(--color-text-muted)',
-                    cursor: busySlug === toolkit.slug ? 'wait' : 'pointer',
-                  }}
+                  className={[
+                    'admin-toolkits__icon-button',
+                    toolkit.enabled ? 'is-active' : '',
+                  ]
+                    .filter(Boolean)
+                    .join(' ')}
                   aria-pressed={toolkit.enabled}
                   title={toolkit.enabled ? 'Disable toolkit' : 'Enable toolkit'}
                 >
@@ -173,16 +149,7 @@ export default function AdminToolkitsPage() {
                         setBusySlug(null)
                       }
                     }}
-                    style={{
-                      background: 'transparent',
-                      border: '0px',
-                      display: 'inline-flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      width: 38,
-                      height: 38,
-                      color: 'var(--color-danger-border)',
-                    }}
+                    className="admin-toolkits__icon-button admin-toolkits__icon-button--danger"
                     title="Uninstall toolkit"
                   >
                     <MaterialIcon name="delete" style={{ fontSize: '1.5rem', color: 'inherit' }} />
@@ -195,12 +162,12 @@ export default function AdminToolkitsPage() {
       </section>
 
       {canInstall && (
-        <section>
+        <section className="admin-toolkits__section">
           <h4 style={{ marginTop: 0, display: 'flex', alignItems: 'center', gap: '0.4rem' }}>
             <MaterialIcon name="cloud_upload" style={{ color: 'var(--color-link)' }} />
             Install toolkit bundle (.zip)
           </h4>
-          <p style={{ margin: '0.25rem 0 1rem', color: 'var(--color-text-secondary)' }}>
+          <p className="admin-toolkits__helper">
             Uploads store the bundle on the server and auto-register the toolkit if it does not already exist. Newly uploaded toolkits remain
             disabled until you review them.
           </p>
@@ -233,7 +200,7 @@ export default function AdminToolkitsPage() {
               setUploading(false)
             }
           }}
-          style={{ display: 'grid', gap: '0.75rem', maxWidth: 420 }}
+          className="admin-toolkits__form"
         >
           <Field label="Slug (optional)">
             <input value={uploadSlug} onChange={(event) => setUploadSlug(event.target.value)} placeholder="Leave blank to use bundle slug" />
@@ -245,29 +212,16 @@ export default function AdminToolkitsPage() {
               onChange={(event) => setUploadFile(event.target.files?.[0] ?? null)}
             />
           </Field>
-          <button
-            type="submit"
-            style={{ width: 'fit-content', display: 'inline-flex', alignItems: 'center', gap: '0.4rem' }}
-            disabled={uploading}
-          >
-            <MaterialIcon name={uploading ? 'hourglass_top' : 'publish'} style={{ fontSize: '1.1rem', color: 'var(--color-text-primary)' }} />
+          <button type="submit" className="tk-button tk-button--primary" disabled={uploading}>
+            <MaterialIcon
+              name={uploading ? 'hourglass_top' : 'publish'}
+              style={{ fontSize: '1.1rem', color: 'inherit' }}
+            />
             {uploading ? 'Uploading…' : 'Upload toolkit'}
-            </button>
+          </button>
           </form>
         </section>
       )}
     </div>
   )
-}
-
-
-const toolkitCardStyle: React.CSSProperties = {
-  border: '1px solid var(--color-border)',
-  borderRadius: 10,
-  padding: '0.95rem 1.1rem',
-  background: 'var(--color-surface-alt)',
-  display: 'flex',
-  justifyContent: 'space-between',
-  alignItems: 'center',
-  gap: '1rem',
 }


### PR DESCRIPTION
## Summary
- replace the toolbox shell inline layout with dedicated CSS so the sidebar stays sticky and its navigation scrolls cleanly with many toolkits
- refresh the admin toolkits experience with consistent form and button styling driven by shared CSS helpers

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_b_68cf5a575e588328be7a385aead4b34e