### PR TITLE
Fix test workflow concurrency deadlock

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: Tests-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- ensure the reusable Tests workflow uses a stable concurrency group name instead of inheriting the caller's name

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68cfd4e6f2548328b315014ab38cb703