### PR TITLE
Fix release build contexts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,10 +105,10 @@ jobs:
       matrix:
         image:
           - name: backend
-            context: backend
+            context: .
             dockerfile: backend/Dockerfile
           - name: frontend
-            context: frontend
+            context: .
             dockerfile: frontend/Dockerfile
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- update the release workflow to build backend and frontend images from the repository root so their Dockerfiles can copy shared assets

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_b_68cfd718fd3c8328830835b62e857c2f