### PR TITLE
feat(latency-sleuth): refine designer tab layout and catalog tools

### DIFF
--- a/ai/state/journal.md
+++ b/ai/state/journal.md
@@ -36,3 +36,8 @@ Track Codex sessions chronologically. Each entry should capture what was attempt
 - Focused on TODO `public-repo-setup`, creating a zipped starter repository with governance docs, automation scripts, and sample toolkit.
 - Packaged artifact `toolkit-community-repo.zip` for maintainers to publish in a dedicated repo without modifying the main codebase.
 - Updated TODO and progress tracking to reflect completion and provide follow-up context for discovery and versioning tasks.
+
+## 2025-09-21 Latency Sleuth designer overhaul
+- Closed TODO `improve-designer-tab` by reshaping the Probe Designer view into a responsive two-column layout with inline catalog actions (`toolkits/latency_sleuth/frontend/components/ProbeDesigner.tsx`; Context7 #1, #7).
+- Added a reusable filtering helper with Vitest coverage to guarantee deterministic search/tag behaviour (`toolkits/latency_sleuth/frontend/components/filterProbeTemplates.ts`, `toolkits/latency_sleuth/frontend/components/__tests__/filterProbeTemplates.test.tsx`; Context7 #6).
+- Ran the Latency Sleuth frontend Vitest config directly via the repository toolchain to confirm the suite stays green (`toolkits/latency_sleuth/frontend/vitest.config.mts`; Context7 #6).

--- a/ai/state/progress.json
+++ b/ai/state/progress.json
@@ -1,10 +1,15 @@
 {
   "version": 1,
-  "last_updated": "2025-09-21T22:59:42Z",
-  "session_counter": 6,
+  "last_updated": "2025-09-21T18:38:45Z",
+  "session_counter": 7,
   "active_task": null,
-  "last_task_id": "public-repo-setup",
+  "last_task_id": "improve-designer-tab",
   "recent_updates": [
+    {
+      "task_id": "improve-designer-tab",
+      "status": "done",
+      "summary": "Reworked Probe Designer into a two-column workflow with catalog filtering, inline edit, and clone actions backed by new helper tests."
+    },
     {
       "task_id": "public-repo-setup",
       "status": "done",

--- a/docs/TODO.yaml
+++ b/docs/TODO.yaml
@@ -55,13 +55,14 @@ areas:
           - "Use existing javascript libraries for heatmap rendering if applicable."
       - id: improve-designer-tab
         title: Improve the Designer tab for better usability.
-        status: backlog
+        status: done
         priority: high
         notes:
           - "Enhance the layout and organization of elements within the Designer tab."
           - "Consider 2-column layout with probe designer on the left and template catalog on the right."
           - "Allow templates in the catalog to be filtered by tags and searched by name."
           - "Allow templates in the catalog to be edited or cloned directly from the catalog."
+          - "2025-09-21: Refactored Probe Designer into a responsive two-column layout with catalog filters, inline edit, and clone actions."
       - id: improve-navigation
         title: Improve navigation within the toolkit UI.
         status: backlog
@@ -132,6 +133,9 @@ areas:
           - "Ensure updates can be rolled back in case of issues."
           - "Consider version compatibility checks before applying updates."
           - "Document the update process for users."
+          - "Allow upload of updated toolkit zips via the UI or API."
+          - "Should validate the zip contents and version before applying."
+          - "Should also support updates from the community repository."
         blockers:
           - "Requires completion of the versioning scheme and update notifications tasks."
       - id: backport-toolkit-update-mechanism

--- a/docs/prompt-engineering/next-task-prompt.md
+++ b/docs/prompt-engineering/next-task-prompt.md
@@ -1,0 +1,30 @@
+Open the repo and load `ai/ops/codex.md` as your system/developer prompt. 
+Use it for all steps in this session and future sessions.
+
+Follow the Work loop:
+
+1) Read: 
+- ai/ops/codex.md 
+- docs/TODO.yaml
+- ai/state/progress.json
+- ai/state/journal.md
+
+2) Select the next task from docs/TODO.yaml (highest priority todo with no unmet dependencies). 
+Explain your selection briefly, citing Context items. 
+
+3) Plan the smallest possible PR (≤500 lines) to satisfy the task acceptance criteria.
+
+4) Propose exact file changes you will make.  
+Output filenames and discription of change. 
+5) After proposal, output the updates you will make to: 
+- docs/TODO.yaml (move task to in_progress or done),
+- ai/state/progress.json (increment step, set last_task_id, update coverage placeholders),
+- ai/state/journal.md (append a dated entry with Context7 references).
+
+6) Stop and wait for me to give approval to apply changes. Do not proceed to another task until I confirm. 
+
+Begin with step 1 and then present step 2 (task selection) and step 3 (plan).
+If modifying a Toolkit, DO NOT modify the Toolbox framework. 
+If modifying the Toolbox framework, DO NOT modify any Toolkits. 
+If you must, ask for approval and provide reason.
+Use context7 MCP to ensure code accuracy and illiminate hallucinations.

--- a/toolkits/latency_sleuth/frontend/components/ProbeDesigner.tsx
+++ b/toolkits/latency_sleuth/frontend/components/ProbeDesigner.tsx
@@ -1,11 +1,12 @@
 import { getReactRuntime } from '../runtime'
 import { useProbeTemplates } from '../hooks/useProbeTemplates'
-import type { NotificationRule, ProbeTemplateCreate } from '../types'
+import type { NotificationRule, ProbeTemplate, ProbeTemplateCreate } from '../types'
+import { filterProbeTemplates } from './filterProbeTemplates'
 
 const React = getReactRuntime()
-const { useMemo, useState } = React
+const { useEffect, useMemo, useState } = React
 
-const methods: ProbeTemplateCreate['method'][] = ['GET', 'HEAD', 'POST']
+const methods: Required<ProbeTemplateCreate>['method'][] = ['GET', 'HEAD', 'POST']
 const channels: NotificationRule['channel'][] = ['slack', 'email', 'pagerduty', 'webhook']
 const thresholds: NotificationRule['threshold'][] = ['breach', 'always', 'recovery']
 
@@ -19,10 +20,106 @@ const formDefaults: ProbeTemplateCreate = {
   tags: [],
 }
 
+type FormMode = 'create' | 'edit'
+
+function toFormState(template: ProbeTemplate): ProbeTemplateCreate {
+  return {
+    name: template.name,
+    description: template.description ?? undefined,
+    url: template.url,
+    method: template.method,
+    sla_ms: template.sla_ms,
+    interval_seconds: template.interval_seconds,
+    notification_rules: template.notification_rules.map((rule) => ({ ...rule })),
+    tags: [...template.tags],
+  }
+}
+
+type TemplateFiltersProps = {
+  searchText: string
+  onSearchChange: (value: string) => void
+  availableTags: string[]
+  selectedTags: string[]
+  onToggleTag: (tag: string) => void
+  onClear: () => void
+}
+
+function TemplateFilters({
+  searchText,
+  onSearchChange,
+  availableTags,
+  selectedTags,
+  onToggleTag,
+  onClear,
+}: TemplateFiltersProps) {
+  return (
+    <div style={{ display: 'grid', gap: '0.5rem' }}>
+      <label className="tk-field-label" style={{ display: 'grid', gap: '0.35rem' }}>
+        Search
+        <input
+          className="tk-input"
+          placeholder="Filter by name or URL"
+          value={searchText}
+          onChange={(event) => onSearchChange(event.target.value)}
+        />
+      </label>
+
+      {availableTags.length > 0 && (
+        <div style={{ display: 'grid', gap: '0.35rem' }}>
+          <span className="tk-field-label">Tags</span>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
+            {availableTags.map((tag) => {
+              const selected = selectedTags.includes(tag)
+              const className = selected ? 'tk-button tk-button--primary' : 'tk-button'
+              return (
+                <button
+                  key={tag}
+                  type="button"
+                  className={className}
+                  onClick={() => onToggleTag(tag)}
+                  aria-pressed={selected}
+                >
+                  {tag}
+                </button>
+              )
+            })}
+            {selectedTags.length > 0 && (
+              <button type="button" className="tk-button" onClick={onClear}>
+                Clear
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
 export default function ProbeDesigner() {
-  const { templates, createTemplate, removeTemplate, loading, error, refresh } = useProbeTemplates()
+  const {
+    templates,
+    templatesById,
+    createTemplate,
+    updateTemplate,
+    removeTemplate,
+    refresh,
+    loading,
+    error,
+  } = useProbeTemplates()
+
   const [formState, setFormState] = useState(formDefaults)
   const [status, setStatus] = useState<string | null>(null)
+  const [formMode, setFormMode] = useState<FormMode>('create')
+  const [activeTemplateId, setActiveTemplateId] = useState<string | null>(null)
+  const [searchText, setSearchText] = useState('')
+  const [selectedTags, setSelectedTags] = useState<string[]>([])
+
+  useEffect(() => {
+    if (!activeTemplateId) return
+    const template = templatesById.get(activeTemplateId)
+    if (!template) return
+    setFormState(toFormState(template))
+  }, [activeTemplateId, templatesById])
 
   const sortedTemplates = useMemo(
     () =>
@@ -32,21 +129,49 @@ export default function ProbeDesigner() {
     [templates],
   )
 
+  const { availableTags, filteredTemplates } = useMemo(
+    () =>
+      filterProbeTemplates(sortedTemplates, {
+        searchText,
+        selectedTags,
+      }),
+    [sortedTemplates, searchText, selectedTags],
+  )
+
+  const activeTemplateName = activeTemplateId ? templatesById.get(activeTemplateId)?.name ?? null : null
+
   const handleSubmit = async (event: any) => {
     event.preventDefault()
     setStatus(null)
-    try {
-      const payload: ProbeTemplateCreate = {
-        ...formState,
-        notification_rules: formState.notification_rules?.filter((rule) => rule.target.trim().length > 0),
-        tags: formState.tags?.filter(Boolean) ?? [],
-      }
-      await createTemplate(payload)
-      setFormState(formDefaults)
-      setStatus('Probe template created')
-    } catch (err) {
-      setStatus(err instanceof Error ? err.message : 'Failed to create template')
+    const payload: ProbeTemplateCreate = {
+      ...formState,
+      notification_rules: formState.notification_rules?.filter((rule) => rule.target.trim().length > 0),
+      tags: formState.tags?.filter((tag) => tag.trim().length > 0) ?? [],
     }
+
+    try {
+      if (formMode === 'edit' && activeTemplateId) {
+        await updateTemplate(activeTemplateId, payload)
+        setStatus('Probe template updated')
+      } else {
+        await createTemplate(payload)
+        setStatus('Probe template created')
+      }
+      setFormState(formDefaults)
+      if (formMode === 'edit') {
+        setFormMode('create')
+        setActiveTemplateId(null)
+      }
+    } catch (err) {
+      setStatus(err instanceof Error ? err.message : 'Failed to save template')
+    }
+  }
+
+  const handleReset = () => {
+    setFormState(formDefaults)
+    setFormMode('create')
+    setActiveTemplateId(null)
+    setStatus(null)
   }
 
   const handleRuleChange = (index: number, key: keyof NotificationRule, value: string) => {
@@ -91,17 +216,52 @@ export default function ProbeDesigner() {
     }))
   }
 
-  return (
-    <div style={{ display: 'grid', gap: '1.25rem' }}>
-      <section className="tk-card" style={{ padding: '1.25rem', display: 'grid', gap: '1rem' }}>
-        <header>
-          <h3 style={{ margin: 0 }}>Probe Designer</h3>
-          <p style={{ margin: '0.25rem 0 0', color: 'var(--color-text-secondary)' }}>
-            Model SLAs, tags, and notification policies before releasing synthetic probes.
-          </p>
-        </header>
+  const beginEdit = (templateId: string) => {
+    setActiveTemplateId(templateId)
+    setFormMode('edit')
+    setStatus(null)
+  }
 
-        <form onSubmit={handleSubmit} style={{ display: 'grid', gap: '0.75rem' }}>
+  const beginClone = (template: ProbeTemplate) => {
+    const cloned = toFormState(template)
+    cloned.name = `${template.name} copy`
+    setFormState(cloned)
+    setFormMode('create')
+    setActiveTemplateId(null)
+    setStatus('Cloning template — adjust fields before saving')
+  }
+
+  const toggleTag = (tag: string) => {
+    setSelectedTags((prev) => (prev.includes(tag) ? prev.filter((item) => item !== tag) : [...prev, tag]))
+  }
+
+  return (
+    <div className="tk-card" style={{ padding: '1.5rem', display: 'grid', gap: '1.5rem' }}>
+      <header>
+        <h3 style={{ margin: 0 }}>Probe Designer</h3>
+        <p style={{ margin: '0.35rem 0 0', color: 'var(--color-text-secondary)' }}>
+          Model SLAs, tags, and notification policies before releasing synthetic probes.
+        </p>
+      </header>
+
+      <div
+        style={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: '1.5rem',
+          alignItems: 'flex-start',
+        }}
+      >
+        <form
+          onSubmit={handleSubmit}
+          style={{
+            flex: '1 1 320px',
+            maxWidth: 480,
+            display: 'grid',
+            gap: '0.75rem',
+            paddingRight: '0.5rem',
+          }}
+        >
           <div>
             <label className="tk-field-label">Name</label>
             <input
@@ -232,69 +392,132 @@ export default function ProbeDesigner() {
             </div>
           </div>
 
-          <div style={{ display: 'flex', gap: '0.75rem', alignItems: 'center' }}>
+          <div style={{ display: 'flex', gap: '0.75rem', alignItems: 'center', flexWrap: 'wrap' }}>
             <button type="submit" className="tk-button tk-button--primary" disabled={loading}>
-              Create template
+              {formMode === 'edit' ? 'Update template' : 'Create template'}
             </button>
+            <button type="button" className="tk-button" onClick={handleReset}>
+              {formMode === 'edit' ? 'Cancel edit' : 'Reset'}
+            </button>
+            {loading && <span style={{ color: 'var(--color-text-secondary)' }}>Saving…</span>}
+          </div>
+
+          <div style={{ display: 'grid', gap: '0.25rem' }}>
+            {formMode === 'edit' && activeTemplateName && (
+              <span style={{ color: 'var(--color-accent)' }}>
+                Editing “{activeTemplateName}” — submit to apply changes or cancel to discard.
+              </span>
+            )}
             {status && <span style={{ color: 'var(--color-text-secondary)' }}>{status}</span>}
             {error && <span style={{ color: 'var(--color-status-error)' }}>{error}</span>}
           </div>
         </form>
-      </section>
 
-      <section className="tk-card" style={{ padding: '1.25rem' }}>
-        <header style={{ marginBottom: '0.75rem', display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '0.75rem' }}>
-          <h3 style={{ margin: 0 }}>Template Catalog</h3>
-          <button className="tk-button" type="button" onClick={() => refresh()} disabled={loading}>
-            Refresh
-          </button>
-        </header>
-        <div style={{ overflowX: 'auto' }}>
-          <table className="tk-table">
-            <thead>
-              <tr>
-                <th>Name</th>
-                <th>URL</th>
-                <th>SLA (ms)</th>
-                <th>Interval</th>
-                <th>Tags</th>
-                <th>Next run</th>
-                <th>Updated</th>
-                <th />
-              </tr>
-            </thead>
-            <tbody>
-              {sortedTemplates.map((template) => (
-                <tr key={template.id}>
-                  <td>{template.name}</td>
-                  <td style={{ maxWidth: 240, wordBreak: 'break-all' }}>{template.url}</td>
-                  <td>{template.sla_ms}</td>
-                  <td>{template.interval_seconds}s</td>
-                  <td>{template.tags.join(', ')}</td>
-                  <td>
-                    {template.next_run_at
-                      ? new Date(template.next_run_at).toLocaleString()
-                      : 'Pending'}
-                  </td>
-                  <td>{new Date(template.updated_at).toLocaleString()}</td>
-                  <td>
-                    <button className="tk-button" type="button" onClick={() => removeTemplate(template.id)}>
-                      Delete
-                    </button>
-                  </td>
-                </tr>
-              ))}
-              {sortedTemplates.length === 0 && (
+        <section style={{ flex: '2 1 440px', minWidth: 320, display: 'grid', gap: '1rem' }}>
+          <header
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              gap: '0.75rem',
+              flexWrap: 'wrap',
+            }}
+          >
+            <div>
+              <h3 style={{ margin: 0 }}>Template Catalog</h3>
+              <p style={{ margin: '0.25rem 0 0', color: 'var(--color-text-secondary)' }}>
+                Filter templates, edit in place, or clone successful probes.
+              </p>
+            </div>
+            <button className="tk-button" type="button" onClick={() => refresh()} disabled={loading}>
+              Refresh
+            </button>
+          </header>
+
+          <TemplateFilters
+            searchText={searchText}
+            onSearchChange={setSearchText}
+            availableTags={availableTags}
+            selectedTags={selectedTags}
+            onToggleTag={toggleTag}
+            onClear={() => setSelectedTags([])}
+          />
+
+          <div style={{ overflowX: 'auto' }}>
+            <table className="tk-table">
+              <thead>
                 <tr>
-                  <td colSpan={8} style={{ textAlign: 'center', padding: '1rem' }}>
-                    {loading ? 'Loading templates…' : 'No templates captured yet.'}
-                  </td>
+                  <th>Name</th>
+                  <th>URL</th>
+                  <th>SLA (ms)</th>
+                  <th>Interval</th>
+                  <th>Tags</th>
+                  <th>Next run</th>
+                  <th>Updated</th>
+                  <th style={{ minWidth: 180 }}>Actions</th>
                 </tr>
-              )}
-            </tbody>
-          </table>
-        </div>
-      </section>
+              </thead>
+              <tbody>
+                {filteredTemplates.map((template) => {
+                  const isEditing = formMode === 'edit' && activeTemplateId === template.id
+                  return (
+                    <tr key={template.id} style={isEditing ? { outline: '2px solid var(--color-accent)' } : undefined}>
+                      <td>{template.name}</td>
+                      <td style={{ maxWidth: 240, wordBreak: 'break-all' }}>{template.url}</td>
+                      <td>{template.sla_ms}</td>
+                      <td>{template.interval_seconds}s</td>
+                      <td>{template.tags.join(', ')}</td>
+                      <td>
+                        {template.next_run_at
+                          ? new Date(template.next_run_at).toLocaleString()
+                          : 'Pending'}
+                      </td>
+                      <td>{new Date(template.updated_at).toLocaleString()}</td>
+                      <td>
+                        <div style={{ display: 'flex', gap: '0.35rem', flexWrap: 'wrap' }}>
+                          <button
+                            className="tk-button"
+                            type="button"
+                            onClick={() => beginEdit(template.id)}
+                          >
+                            Edit
+                          </button>
+                          <button
+                            className="tk-button"
+                            type="button"
+                            onClick={() => beginClone(template)}
+                          >
+                            Clone
+                          </button>
+                          <button
+                            className="tk-button"
+                            type="button"
+                            onClick={() => removeTemplate(template.id)}
+                          >
+                            Delete
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  )
+                })}
+                {filteredTemplates.length === 0 && (
+                  <tr>
+                    <td colSpan={8} style={{ textAlign: 'center', padding: '1rem' }}>
+                      {loading
+                        ? 'Loading templates…'
+                        : searchText || selectedTags.length > 0
+                          ? 'No templates match the current filters.'
+                          : 'No templates captured yet.'}
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </div>
     </div>
   )
 }
+

--- a/toolkits/latency_sleuth/frontend/components/__tests__/filterProbeTemplates.test.tsx
+++ b/toolkits/latency_sleuth/frontend/components/__tests__/filterProbeTemplates.test.tsx
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ProbeTemplate } from '../../types'
+import { filterProbeTemplates } from '../filterProbeTemplates'
+
+const baseTemplate: ProbeTemplate = {
+  id: 'base',
+  name: 'Base Template',
+  description: null,
+  url: 'https://example.com/base',
+  method: 'GET',
+  sla_ms: 100,
+  interval_seconds: 60,
+  notification_rules: [],
+  tags: [],
+  created_at: new Date('2025-01-01T00:00:00Z').toISOString(),
+  updated_at: new Date('2025-01-01T00:00:00Z').toISOString(),
+}
+
+describe('filterProbeTemplates', () => {
+  const templates: ProbeTemplate[] = [
+    {
+      ...baseTemplate,
+      id: 'checkout',
+      name: 'Checkout Flow',
+      url: 'https://shop.example.com/pay',
+      tags: ['checkout', 'critical'],
+    },
+    {
+      ...baseTemplate,
+      id: 'auth',
+      name: 'Auth Service',
+      url: 'https://auth.example.com/login',
+      tags: ['auth', 'critical'],
+    },
+    {
+      ...baseTemplate,
+      id: 'docs',
+      name: 'Docs Portal',
+      url: 'https://example.com/docs',
+      tags: ['docs'],
+    },
+  ]
+
+  it('derives alphabetised available tags', () => {
+    const { availableTags } = filterProbeTemplates(templates)
+    expect(availableTags).toEqual(['auth', 'checkout', 'critical', 'docs'])
+  })
+
+  it('filters by search string across name and url', () => {
+    const { filteredTemplates } = filterProbeTemplates(templates, { searchText: 'checkout' })
+    expect(filteredTemplates).toHaveLength(1)
+    expect(filteredTemplates[0].id).toBe('checkout')
+
+    const { filteredTemplates: urlFiltered } = filterProbeTemplates(templates, {
+      searchText: 'auth.example.com',
+    })
+    expect(urlFiltered).toHaveLength(1)
+    expect(urlFiltered[0].id).toBe('auth')
+  })
+
+  it('requires templates to contain all selected tags', () => {
+    const { filteredTemplates } = filterProbeTemplates(templates, {
+      selectedTags: ['critical', 'checkout'],
+    })
+    expect(filteredTemplates).toHaveLength(1)
+    expect(filteredTemplates[0].id).toBe('checkout')
+  })
+
+  it('ignores duplicate and empty tag filters', () => {
+    const { filteredTemplates } = filterProbeTemplates(templates, {
+      selectedTags: [' critical ', 'CRITICAL', '', 'auth'],
+    })
+    expect(filteredTemplates).toHaveLength(1)
+    expect(filteredTemplates[0].id).toBe('auth')
+  })
+
+  it('combines search and tag filters using logical AND', () => {
+    const { filteredTemplates } = filterProbeTemplates(templates, {
+      searchText: 'Portal',
+      selectedTags: ['docs'],
+    })
+    expect(filteredTemplates).toHaveLength(1)
+    expect(filteredTemplates[0].id).toBe('docs')
+
+    const none = filterProbeTemplates(templates, {
+      searchText: 'Portal',
+      selectedTags: ['auth'],
+    })
+    expect(none.filteredTemplates).toHaveLength(0)
+  })
+})
+

--- a/toolkits/latency_sleuth/frontend/components/filterProbeTemplates.ts
+++ b/toolkits/latency_sleuth/frontend/components/filterProbeTemplates.ts
@@ -1,0 +1,80 @@
+import type { ProbeTemplate } from '../types'
+
+type FilterResult = {
+  availableTags: string[]
+  filteredTemplates: ProbeTemplate[]
+}
+
+type NormalizeOptions = {
+  searchText?: string
+  selectedTags?: string[]
+}
+
+function normalizeSearch(searchText?: string): string {
+  return (searchText ?? '').trim().toLowerCase()
+}
+
+function normalizeTags(selectedTags?: string[]): string[] {
+  const seen = new Set<string>()
+  const normalized: string[] = []
+
+  for (const raw of selectedTags ?? []) {
+    const tag = raw.trim()
+    if (!tag) continue
+    const lower = tag.toLowerCase()
+    if (seen.has(lower)) continue
+    seen.add(lower)
+    normalized.push(lower)
+  }
+
+  return normalized
+}
+
+function collectAvailableTags(templates: ProbeTemplate[]): string[] {
+  const unique = new Set<string>()
+
+  for (const template of templates) {
+    for (const tag of template.tags ?? []) {
+      const normalized = tag.trim()
+      if (!normalized) continue
+      unique.add(normalized)
+    }
+  }
+
+  return Array.from(unique).sort((a, b) => a.localeCompare(b))
+}
+
+function matchesSearch(template: ProbeTemplate, search: string): boolean {
+  if (!search) return true
+  const haystack = `${template.name}\n${template.url}`.toLowerCase()
+  return haystack.includes(search)
+}
+
+function matchesTags(template: ProbeTemplate, normalizedTags: string[]): boolean {
+  if (normalizedTags.length === 0) return true
+  const templateTags = new Set((template.tags ?? []).map((tag) => tag.toLowerCase()))
+
+  for (const tag of normalizedTags) {
+    if (!templateTags.has(tag)) {
+      return false
+    }
+  }
+
+  return true
+}
+
+export function filterProbeTemplates(
+  templates: ProbeTemplate[],
+  options: NormalizeOptions = {},
+): FilterResult {
+  const search = normalizeSearch(options.searchText)
+  const normalizedTags = normalizeTags(options.selectedTags)
+  const availableTags = collectAvailableTags(templates)
+
+  const filteredTemplates = templates.filter(
+    (template) => matchesSearch(template, search) && matchesTags(template, normalizedTags),
+  )
+
+  return { availableTags, filteredTemplates }
+}
+


### PR DESCRIPTION
## Summary
- refactor Probe Designer into a responsive two-column flow with inline edit/clone actions
- add reusable helper plus Vitest coverage for catalog search and tag filtering
- update backlog/state files now that `improve-designer-tab` is closed

## Testing
- ./frontend/node_modules/.bin/vitest run --config toolkits/latency_sleuth/frontend/vitest.config.mts
