### PR TITLE
chore: require explicit postgres credentials for local compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,11 +16,19 @@ VITE_API_BASE_URL=http://localhost:8080
 # VITE_DEV_API_PROXY=http://localhost:8080
 # VITE_API_PORT=8080
 
-# Database (PostgreSQL via Docker compose defaults)
-DATABASE_URL=postgresql+asyncpg://sretoolbox:sretoolbox@db:5432/sretoolbox
-POSTGRES_USER=sretoolbox
-POSTGRES_PASSWORD=sretoolbox
-POSTGRES_DB=sretoolbox
+# Database (PostgreSQL via Docker compose)
+# Generate unique credentials (for example:
+#   python - <<'PY'
+#   import secrets, string
+#   alphabet = string.ascii_letters + string.digits
+#   print(''.join(secrets.choice(alphabet) for _ in range(32)))
+#   PY
+# )
+# Replace the placeholders below before launching docker compose.
+DATABASE_URL=postgresql+asyncpg://toolbox_app:CHANGE_ME_POSTGRES_PASSWORD@db:5432/toolbox
+POSTGRES_USER=toolbox_app
+POSTGRES_PASSWORD=CHANGE_ME_POSTGRES_PASSWORD
+POSTGRES_DB=toolbox
 
 # Authentication defaults
 # Generate a random value (>=32 chars), e.g. `openssl rand -hex 32`

--- a/README.md
+++ b/README.md
@@ -100,10 +100,10 @@ Run shared infrastructure in containers and execute the application processes lo
    ./bootstrap-stack.sh
    ```
 
-2. Override connection strings in `.env` for localhost access (example values):
+2. Override connection strings in `.env` for localhost access (use the same credentials you provisioned for Postgres):
 
    ```dotenv
-   DATABASE_URL=postgresql+asyncpg://sretoolbox:sretoolbox@127.0.0.1:5432/sretoolbox
+   DATABASE_URL=postgresql+asyncpg://<postgres_user>:<postgres_password>@127.0.0.1:5432/<postgres_db>
    REDIS_URL=redis://127.0.0.1:6379/0
    VAULT_ADDR=http://127.0.0.1:8200
    FRONTEND_BASE_URL=http://localhost:5173

--- a/ai/state/journal.md
+++ b/ai/state/journal.md
@@ -41,3 +41,8 @@ Track Codex sessions chronologically. Each entry should capture what was attempt
 - Closed TODO `improve-designer-tab` by reshaping the Probe Designer view into a responsive two-column layout with inline catalog actions (`toolkits/latency_sleuth/frontend/components/ProbeDesigner.tsx`; Context7 #1, #7).
 - Added a reusable filtering helper with Vitest coverage to guarantee deterministic search/tag behaviour (`toolkits/latency_sleuth/frontend/components/filterProbeTemplates.ts`, `toolkits/latency_sleuth/frontend/components/__tests__/filterProbeTemplates.test.tsx`; Context7 #6).
 - Ran the Latency Sleuth frontend Vitest config directly via the repository toolchain to confirm the suite stays green (`toolkits/latency_sleuth/frontend/vitest.config.mts`; Context7 #6).
+
+## 2025-09-21 Postgres credential hardening
+- Moved TODO `remove-default-postgres-creds` to in_progress and stripped docker-compose defaults so Postgres credentials must be supplied explicitly (`docs/TODO.yaml`, `docker-compose.yml`).
+- Refreshed `.env.example`, the manual dev workflow, and the Docker Compose checklist so operators generate their own secrets before booting the stack (`.env.example`, `README.md`, `docs/project-setup.md`).
+- Rendered the compose config with the updated `.env` to confirm required variables behave as expected (`docker compose config`; `docker-compose.yml`).

--- a/ai/state/progress.json
+++ b/ai/state/progress.json
@@ -1,9 +1,9 @@
 {
   "version": 1,
-  "last_updated": "2025-09-21T18:38:45Z",
-  "session_counter": 7,
-  "active_task": null,
-  "last_task_id": "improve-designer-tab",
+  "last_updated": "2025-09-21T19:05:00Z",
+  "session_counter": 8,
+  "active_task": "remove-default-postgres-creds",
+  "last_task_id": "remove-default-postgres-creds",
   "recent_updates": [
     {
       "task_id": "improve-designer-tab",
@@ -41,12 +41,6 @@
       "summary": "Enforced non-default JWT secrets with startup validation and refreshed operator docs."
     }
   ],
-  "candidate_next_tasks": [
-    {
-      "task_id": "remove-default-postgres-creds",
-      "status": "backlog",
-      "reason": "Default credentials linger in docker-compose and should be eliminated."
-    }
-  ],
+  "candidate_next_tasks": [],
   "notes": "Initialised by Codex; update this file whenever focus or status changes. Architecture/schema references refreshed in session 2."
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,15 +104,15 @@ services:
     container_name: sre-toolbox-db
     env_file: .env
     environment:
-      POSTGRES_USER: ${POSTGRES_USER:-sretoolbox}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-sretoolbox}
-      POSTGRES_DB: ${POSTGRES_DB:-sretoolbox}
+      POSTGRES_USER: ${POSTGRES_USER:?POSTGRES_USER is required}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+      POSTGRES_DB: ${POSTGRES_DB:?POSTGRES_DB is required}
     ports:
       - "5432:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-sretoolbox} -d ${POSTGRES_DB:-sretoolbox}"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
       interval: 5s
       timeout: 5s
       retries: 10

--- a/docs/TODO.yaml
+++ b/docs/TODO.yaml
@@ -193,10 +193,11 @@ areas:
           - "2025-09-21: Added bootstrap-stack.sh to start core containers, initialise Vault once, and seed placeholder secrets without overwriting existing data."
       - id: remove-default-postgres-creds
         title: Remove default Postgres credentials from docker-compose and require overrides.
-        status: backlog
+        status: in_progress
         priority: medium
         notes:
           - "Consider interactive prompts or environment validation in tooling scripts."
+          - "2025-09-21: Removing docker-compose defaults and updating docs to require operator-supplied credentials."
   - id: governance
     title: Governance & planning
     summary: Operational guardrails for community contributions and secret management.

--- a/docs/project-setup.md
+++ b/docs/project-setup.md
@@ -36,7 +36,7 @@ Ensure PostgreSQL, Redis, and Vault are running (e.g. by executing `./bootstrap-
 > while allowing the SPA to perform SSO hand-offs locally.
 
 ## Docker Compose (all services)
-1. Copy `.env.example` to `.env`, then replace the JWT placeholder with a random ≥32 character secret (for example, run `openssl rand -hex 32`). Leave the Vault settings in place while you customise bootstrap admin credentials.
+1. Copy `.env.example` to `.env`, then generate strong values for `POSTGRES_USER`, `POSTGRES_PASSWORD`, and (optionally) `POSTGRES_DB`. Update `DATABASE_URL` to match those credentials and replace the JWT placeholder with a random ≥32 character secret (for example, run `openssl rand -hex 32`). The compose stack refuses to start if the Postgres secrets are left blank.
 2. Run `./bootstrap-stack.sh` (see **Secrets Manager** below) so Vault is initialised, unsealed, and seeded before other services start.
 3. Run `docker compose up --build` from the repo root. The API performs migrations automatically on start-up.
 4. Visit:


### PR DESCRIPTION
## Summary
- require operators to provide POSTGRES_* values by removing docker-compose fallbacks
- refresh .env example plus docs so unique credentials are generated before running the stack
- document the work-in-progress state for remove-default-postgres-creds in our tracking files

## Testing
- docker compose config

