### PR TITLE
Add bootstrap Postgres env preflight

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,11 +24,11 @@ VITE_API_BASE_URL=http://localhost:8080
 #   print(''.join(secrets.choice(alphabet) for _ in range(32)))
 #   PY
 # )
-# Replace the placeholders below before launching docker compose.
-DATABASE_URL=postgresql+asyncpg://toolbox_app:CHANGE_ME_POSTGRES_PASSWORD@db:5432/toolbox
-POSTGRES_USER=toolbox_app
-POSTGRES_PASSWORD=CHANGE_ME_POSTGRES_PASSWORD
-POSTGRES_DB=toolbox
+# Replace every placeholder before launching docker compose — the bootstrap helper refuses to run otherwise.
+DATABASE_URL=postgresql+asyncpg://__REPLACE_WITH_POSTGRES_USER__:__REPLACE_WITH_POSTGRES_PASSWORD__@db:5432/__REPLACE_WITH_POSTGRES_DB__
+POSTGRES_USER=__REPLACE_WITH_POSTGRES_USER__
+POSTGRES_PASSWORD=__REPLACE_WITH_POSTGRES_PASSWORD__
+POSTGRES_DB=__REPLACE_WITH_POSTGRES_DB__
 
 # Authentication defaults
 # Generate a random value (>=32 chars), e.g. `openssl rand -hex 32`

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ SRE Toolbox is a modular operations cockpit for site reliability teams. The ligh
 
 ## Quick start (Docker Compose)
 
-1. Copy `.env.example` to `.env` and adjust values (set fresh JWT secrets, choose an admin bootstrap password, and leave the Vault settings in place). The services read this file automatically during startup.
-2. Run the bootstrap helper to start core services (Postgres, Redis, Vault) and perform the one-time Vault initialisation. The script will skip work that has already been completed and will never overwrite existing unseal keys or secrets:
+1. Copy `.env.example` to `.env` and replace **all** Postgres placeholders with unique values. Ensure the discrete variables (`POSTGRES_*`) and `DATABASE_URL` stay in sync, then set fresh JWT secrets and an admin bootstrap password. The services read this file automatically during startup.
+2. Run the bootstrap helper to start core services (Postgres, Redis, Vault) and perform the one-time Vault initialisation. The helper now validates your Postgres credentials up front and exits with actionable guidance if placeholders remain:
 
    ```bash
    ./bootstrap-stack.sh
@@ -94,7 +94,7 @@ See `docs/project-setup.md` for a deeper walkthrough and production hardening ch
 
 Run shared infrastructure in containers and execute the application processes locally for faster iteration.
 
-1. Start dependencies (Postgres, Redis, Vault) with the bootstrap helper so Vault is initialised and unsealed automatically:
+1. Start dependencies (Postgres, Redis, Vault) with the bootstrap helper so Vault is initialised and unsealed automatically. The helper refuses to proceed if `POSTGRES_*` variables or `DATABASE_URL` still use placeholders:
 
    ```bash
    ./bootstrap-stack.sh

--- a/ai/state/journal.md
+++ b/ai/state/journal.md
@@ -46,3 +46,8 @@ Track Codex sessions chronologically. Each entry should capture what was attempt
 - Moved TODO `remove-default-postgres-creds` to in_progress and stripped docker-compose defaults so Postgres credentials must be supplied explicitly (`docs/TODO.yaml`, `docker-compose.yml`).
 - Refreshed `.env.example`, the manual dev workflow, and the Docker Compose checklist so operators generate their own secrets before booting the stack (`.env.example`, `README.md`, `docs/project-setup.md`).
 - Rendered the compose config with the updated `.env` to confirm required variables behave as expected (`docker compose config`; `docker-compose.yml`).
+
+## 2025-09-21 Postgres bootstrap validation
+- Closed TODO `remove-default-postgres-creds` by wiring a new env preflight into `bootstrap-stack.sh` that rejects placeholder Postgres credentials before Docker services launch (`backend/app/core/postgres_env.py`, `bootstrap-stack.sh`; Context: docs/TODO.yaml).
+- Added pytest coverage to lock the validator’s behaviour around placeholders, mismatched `DATABASE_URL` values, and minimum password length (`backend/tests/test_postgres_env.py`; Context: backend tests).
+- Refreshed onboarding docs and `.env.example` so operators have to replace every Postgres placeholder before running the helper (`README.md`, `docs/project-setup.md`, `.env.example`; Context: onboarding docs).

--- a/ai/state/progress.json
+++ b/ai/state/progress.json
@@ -1,10 +1,15 @@
 {
   "version": 1,
-  "last_updated": "2025-09-21T19:05:00Z",
-  "session_counter": 8,
-  "active_task": "remove-default-postgres-creds",
+  "last_updated": "2025-09-22T02:09:31Z",
+  "session_counter": 9,
+  "active_task": null,
   "last_task_id": "remove-default-postgres-creds",
   "recent_updates": [
+    {
+      "task_id": "remove-default-postgres-creds",
+      "status": "done",
+      "summary": "Added a bootstrap preflight that validates Postgres credentials and refreshed onboarding docs to require unique values."
+    },
     {
       "task_id": "improve-designer-tab",
       "status": "done",

--- a/backend/app/core/postgres_env.py
+++ b/backend/app/core/postgres_env.py
@@ -77,11 +77,15 @@ def _validate_database_url(env: Mapping[str, str], errors: list[str]) -> None:
     expected_user = env.get("POSTGRES_USER", "")
     expected_password = env.get("POSTGRES_PASSWORD", "")
     expected_db = env.get("POSTGRES_DB", "")
-    if username and expected_user and username != expected_user:
+    if expected_user and not username:
+        errors.append("DATABASE_URL must include a username when POSTGRES_USER is set")
+    elif username and expected_user and username != expected_user:
         errors.append(
             "DATABASE_URL username does not match POSTGRES_USER; update one of them"
         )
-    if password and expected_password and password != expected_password:
+    if expected_password and not password:
+        errors.append("DATABASE_URL must include a password when POSTGRES_PASSWORD is set")
+    elif password and expected_password and password != expected_password:
         errors.append(
             "DATABASE_URL password does not match POSTGRES_PASSWORD; update one of them"
         )

--- a/backend/app/core/postgres_env.py
+++ b/backend/app/core/postgres_env.py
@@ -1,0 +1,123 @@
+"""Runtime validation for Postgres environment variables used by the stack helper."""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass
+from typing import Iterable, Mapping
+from urllib.parse import unquote, urlsplit
+
+PLACEHOLDER_TOKENS: tuple[str, ...] = (
+    "CHANGE_ME",
+    "__REPLACE",
+    "<REPLACE",
+)
+MIN_PASSWORD_LENGTH = 12
+REQUIRED_VARS: tuple[str, ...] = (
+    "POSTGRES_USER",
+    "POSTGRES_PASSWORD",
+    "POSTGRES_DB",
+    "DATABASE_URL",
+)
+ALLOWED_DATABASE_SCHEMES = {"postgresql", "postgresql+asyncpg"}
+
+
+@dataclass(slots=True)
+class PostgresEnvError(RuntimeError):
+    errors: tuple[str, ...]
+
+    def __str__(self) -> str:  # pragma: no cover - inherited behaviour exercised via tests
+        return "\n".join(self.errors)
+
+
+def _looks_like_placeholder(value: str | None) -> bool:
+    if not value:
+        return False
+    lowered = value.lower()
+    if lowered in {"postgres", "password", "changeme", "change-me", "postgres_password"}:
+        return True
+    for token in PLACEHOLDER_TOKENS:
+        if token.lower() in lowered:
+            return True
+    return False
+
+
+def _ensure_required(env: Mapping[str, str], errors: list[str]) -> None:
+    for key in REQUIRED_VARS:
+        raw = env.get(key, "").strip()
+        if not raw:
+            errors.append(f"{key} must be set before running the stack helper")
+        elif _looks_like_placeholder(raw):
+            errors.append(f"{key} still uses a placeholder value; generate a unique secret")
+
+
+def _validate_password(password: str | None, errors: list[str]) -> None:
+    if not password:
+        return
+    if len(password) < MIN_PASSWORD_LENGTH:
+        errors.append("POSTGRES_PASSWORD must be at least 12 characters long")
+
+
+def _validate_database_url(env: Mapping[str, str], errors: list[str]) -> None:
+    url = env.get("DATABASE_URL")
+    if not url:
+        return
+    parsed = urlsplit(url)
+    scheme = parsed.scheme.lower()
+    if scheme not in ALLOWED_DATABASE_SCHEMES:
+        errors.append(
+            "DATABASE_URL must use the postgresql+asyncpg scheme (or postgresql for sync clients)"
+        )
+        return
+    username = unquote(parsed.username or "")
+    password = unquote(parsed.password or "")
+    database = (parsed.path or "").lstrip("/")
+    # Track mismatches with the discrete env vars so compose gets a consistent configuration.
+    expected_user = env.get("POSTGRES_USER", "")
+    expected_password = env.get("POSTGRES_PASSWORD", "")
+    expected_db = env.get("POSTGRES_DB", "")
+    if username and expected_user and username != expected_user:
+        errors.append(
+            "DATABASE_URL username does not match POSTGRES_USER; update one of them"
+        )
+    if password and expected_password and password != expected_password:
+        errors.append(
+            "DATABASE_URL password does not match POSTGRES_PASSWORD; update one of them"
+        )
+    if database and expected_db and database != expected_db:
+        errors.append(
+            "DATABASE_URL database name does not match POSTGRES_DB; update one of them"
+        )
+    if _looks_like_placeholder(username) or _looks_like_placeholder(password):
+        errors.append("DATABASE_URL still contains placeholder credentials; replace them")
+
+
+def validate_postgres_env(env: Mapping[str, str] | None = None) -> None:
+    env_map = env or os.environ
+    # Build a fresh list so tests can assert on deterministic messaging.
+    issues: list[str] = []
+    _ensure_required(env_map, issues)
+    _validate_password(env_map.get("POSTGRES_PASSWORD"), issues)
+    _validate_database_url(env_map, issues)
+    if issues:
+        raise PostgresEnvError(tuple(issues))
+
+
+def main(argv: Iterable[str] | None = None) -> int:  # pragma: no cover - exercised via CLI wrapper
+    try:
+        validate_postgres_env()
+    except PostgresEnvError as exc:  # pragma: no cover - behaviour verified through tests
+        print("Postgres credential validation failed:", file=sys.stderr)
+        for line in exc.errors:
+            print(f"  - {line}", file=sys.stderr)
+        print(
+            "Update .env (or the invoking environment) before rerunning ./bootstrap-stack.sh.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution path
+    raise SystemExit(main())

--- a/backend/tests/test_postgres_env.py
+++ b/backend/tests/test_postgres_env.py
@@ -58,6 +58,15 @@ def test_validate_postgres_env_rejects_placeholder_in_database_url(valid_env: Di
     assert "placeholder credentials" in joined
 
 
+def test_validate_postgres_env_requires_database_url_credentials(valid_env: Dict[str, str]) -> None:
+    valid_env["DATABASE_URL"] = "postgresql+asyncpg://db:5432/toolbox"
+    with pytest.raises(PostgresEnvError) as exc:
+        validate_postgres_env(valid_env)
+    joined = "\n".join(exc.value.errors)
+    assert "must include a username" in joined
+    assert "must include a password" in joined
+
+
 def test_validate_postgres_env_allows_plain_postgresql_scheme(valid_env: Dict[str, str]) -> None:
     valid_env["DATABASE_URL"] = "postgresql://toolbox_admin:S0m3-Super-Secret!@db:5432/toolbox"
     validate_postgres_env(valid_env)

--- a/backend/tests/test_postgres_env.py
+++ b/backend/tests/test_postgres_env.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from typing import Dict
+
+import pytest
+
+from app.core.postgres_env import PostgresEnvError, validate_postgres_env
+
+
+@pytest.fixture(name="valid_env")
+def _valid_env() -> Dict[str, str]:
+    return {
+        "POSTGRES_USER": "toolbox_admin",
+        "POSTGRES_PASSWORD": "S0m3-Super-Secret!",
+        "POSTGRES_DB": "toolbox",
+        "DATABASE_URL": "postgresql+asyncpg://toolbox_admin:S0m3-Super-Secret!@db:5432/toolbox",
+    }
+
+
+def test_validate_postgres_env_accepts_secure_values(valid_env: Dict[str, str]) -> None:
+    validate_postgres_env(valid_env)
+
+
+def test_validate_postgres_env_rejects_missing_fields(valid_env: Dict[str, str]) -> None:
+    del valid_env["POSTGRES_PASSWORD"]
+    with pytest.raises(PostgresEnvError) as exc:
+        validate_postgres_env(valid_env)
+    assert "POSTGRES_PASSWORD must be set" in "\n".join(exc.value.errors)
+
+
+def test_validate_postgres_env_rejects_placeholder_password(valid_env: Dict[str, str]) -> None:
+    valid_env["POSTGRES_PASSWORD"] = "CHANGE_ME_POSTGRES_PASSWORD"
+    with pytest.raises(PostgresEnvError) as exc:
+        validate_postgres_env(valid_env)
+    joined = "\n".join(exc.value.errors)
+    assert "placeholder" in joined
+
+
+def test_validate_postgres_env_rejects_short_password(valid_env: Dict[str, str]) -> None:
+    valid_env["POSTGRES_PASSWORD"] = "short_pwd"
+    with pytest.raises(PostgresEnvError) as exc:
+        validate_postgres_env(valid_env)
+    assert "at least 12" in "\n".join(exc.value.errors)
+
+
+def test_validate_postgres_env_requires_database_url_alignment(valid_env: Dict[str, str]) -> None:
+    valid_env["DATABASE_URL"] = "postgresql+asyncpg://other_user:S0m3-Super-Secret!@db:5432/toolbox"
+    with pytest.raises(PostgresEnvError) as exc:
+        validate_postgres_env(valid_env)
+    assert "username does not match" in "\n".join(exc.value.errors)
+
+
+def test_validate_postgres_env_rejects_placeholder_in_database_url(valid_env: Dict[str, str]) -> None:
+    valid_env["DATABASE_URL"] = "postgresql+asyncpg://toolbox_admin:CHANGE_ME_POSTGRES_PASSWORD@db:5432/toolbox"
+    with pytest.raises(PostgresEnvError) as exc:
+        validate_postgres_env(valid_env)
+    joined = "\n".join(exc.value.errors)
+    assert "placeholder credentials" in joined
+
+
+def test_validate_postgres_env_allows_plain_postgresql_scheme(valid_env: Dict[str, str]) -> None:
+    valid_env["DATABASE_URL"] = "postgresql://toolbox_admin:S0m3-Super-Secret!@db:5432/toolbox"
+    validate_postgres_env(valid_env)
+
+
+def test_main_reads_process_environment(valid_env: Dict[str, str], monkeypatch: pytest.MonkeyPatch) -> None:
+    for key, value in valid_env.items():
+        monkeypatch.setenv(key, value)
+    # Should not raise when env vars are set on the process.
+    validate_postgres_env(None)
+
+
+def test_validate_postgres_env_rejects_placeholder_database_name(valid_env: Dict[str, str]) -> None:
+    valid_env["POSTGRES_DB"] = "__REPLACE_WITH_DB__"
+    valid_env["DATABASE_URL"] = "postgresql+asyncpg://toolbox_admin:S0m3-Super-Secret!@db:5432/__REPLACE_WITH_DB__"
+    with pytest.raises(PostgresEnvError) as exc:
+        validate_postgres_env(valid_env)
+    joined = "\n".join(exc.value.errors)
+    assert "placeholder" in joined

--- a/bootstrap-stack.sh
+++ b/bootstrap-stack.sh
@@ -76,6 +76,12 @@ resolve_host_path() {
   fi
 }
 
+validate_postgres_env() {
+  info "Validating Postgres credentials"
+  PYTHONPATH="$ROOT_DIR/backend${PYTHONPATH:+:$PYTHONPATH}" python3 -m app.core.postgres_env \
+    || fatal "Postgres credential validation failed"
+}
+
 start_infrastructure() {
   info "Starting Docker services (db, redis, vault)"
   "${DOCKER_COMPOSE[@]}" up -d db redis vault
@@ -305,6 +311,7 @@ main() {
   require_command python3
   configure_docker_compose
   load_env_file
+  validate_postgres_env
   start_infrastructure
   ensure_vault_data_permissions
   bootstrap_vault

--- a/docs/TODO.yaml
+++ b/docs/TODO.yaml
@@ -193,11 +193,12 @@ areas:
           - "2025-09-21: Added bootstrap-stack.sh to start core containers, initialise Vault once, and seed placeholder secrets without overwriting existing data."
       - id: remove-default-postgres-creds
         title: Remove default Postgres credentials from docker-compose and require overrides.
-        status: in_progress
+        status: done
         priority: medium
         notes:
           - "Consider interactive prompts or environment validation in tooling scripts."
           - "2025-09-21: Removing docker-compose defaults and updating docs to require operator-supplied credentials."
+          - "2025-09-21: Added bootstrap preflight that rejects placeholder Postgres credentials and refreshed onboarding docs."
   - id: governance
     title: Governance & planning
     summary: Operational guardrails for community contributions and secret management.

--- a/docs/project-setup.md
+++ b/docs/project-setup.md
@@ -36,8 +36,8 @@ Ensure PostgreSQL, Redis, and Vault are running (e.g. by executing `./bootstrap-
 > while allowing the SPA to perform SSO hand-offs locally.
 
 ## Docker Compose (all services)
-1. Copy `.env.example` to `.env`, then generate strong values for `POSTGRES_USER`, `POSTGRES_PASSWORD`, and (optionally) `POSTGRES_DB`. Update `DATABASE_URL` to match those credentials and replace the JWT placeholder with a random ≥32 character secret (for example, run `openssl rand -hex 32`). The compose stack refuses to start if the Postgres secrets are left blank.
-2. Run `./bootstrap-stack.sh` (see **Secrets Manager** below) so Vault is initialised, unsealed, and seeded before other services start.
+1. Copy `.env.example` to `.env`, then replace every Postgres placeholder (`POSTGRES_*` and the credentials embedded in `DATABASE_URL`). The bootstrap helper refuses to run while placeholders remain, so generate new values first (for example, run `openssl rand -hex 32` and paste the output into both `POSTGRES_PASSWORD` and the URL).
+2. Run `./bootstrap-stack.sh` (see **Secrets Manager** below) so Vault is initialised, unsealed, and seeded before other services start. The script now validates the Postgres configuration up front and exits early with guidance if values are inconsistent.
 3. Run `docker compose up --build` from the repo root. The API performs migrations automatically on start-up.
 4. Visit:
    - UI → http://localhost:5173


### PR DESCRIPTION
## Summary
- add a Postgres env validator that rejects placeholders, weak passwords, and DATABASE_URL mismatches before the stack helper launches Docker
- call the validator from bootstrap-stack.sh and fail fast when credentials are incomplete
- refresh .env.example plus onboarding docs so operators must replace every placeholder, and update Codex state/TODO tracking

## Testing
- cd backend && pytest tests/test_postgres_env.py
