### PR TITLE
Add toolkit documentation overviews for operator workflows

### DIFF
--- a/toolkits/api_checker/docs/OPERATOR.md
+++ b/toolkits/api_checker/docs/OPERATOR.md
@@ -1,0 +1,37 @@
+# API Checker Operator Guide
+
+Use this runbook to exercise HTTP requests against internal or third-party services when verifying incidents, regression fixes, or SLA compliance.
+
+## Build a Request
+1. Open **Toolkits → API Checker**.
+2. Select the HTTP method and provide the full URL, including query string if required.
+3. Configure optional inputs:
+   - Add query parameters and headers. Toggle entries off to keep them for later without sending them.
+   - Set a timeout (1–120 seconds) and decide whether redirects should be followed.
+   - Choose a request body mode:
+     - **None** – send no payload.
+     - **Raw** – paste any text payload. Optionally override the `Content-Type` header.
+     - **JSON** – paste JSON content; the toolkit validates syntax before sending.
+   - Pick an authentication mode:
+     - **Basic** – provide username and password.
+     - **Bearer** – supply an access token; the header is added automatically.
+     - **API Key** – define a custom header name/value pair.
+
+## Execute and Review
+1. Click **Send Request**. The request is issued via the toolkit backend using your configuration.
+2. On success, review:
+   - Status line and HTTP version.
+   - Total duration, payload size, and detected content type.
+   - Response body preview (with truncation notice when over 64 KB) and JSON formatting when available.
+   - Response and request headers side by side for auditing.
+3. On failure, read the surfaced error banner. Timeout and validation errors include actionable guidance (e.g., malformed JSON).
+
+## Manage History
+- Every request is saved automatically with timestamp, configuration, and response outcome.
+- Use the **History** panel to replay an entry; selecting one repopulates the form for iterative testing.
+- Clear history when you need to scrub sensitive headers. Up to 25 entries are retained to avoid stale clutter.
+
+## Operational Tips
+- Duplicate an entry and disable headers to simulate degraded clients without losing the full configuration.
+- Combine API Checker results with latency dashboards to confirm whether regressions are client-side or server-side.
+- Export response payloads or headers when filing incident reports or regression tickets.

--- a/toolkits/api_checker/docs/README.md
+++ b/toolkits/api_checker/docs/README.md
@@ -1,0 +1,13 @@
+# API Checker Overview
+
+## Purpose
+The API Checker accelerates HTTP endpoint validation by giving operators a scriptable request composer, response inspector, and sharable history so regressions and outage details can be captured in minutes.
+
+## Primary Workflows
+1. **Compose requests quickly.** Choose an HTTP method, set the URL, and add query parameters or headers with on/off toggles to mirror real client behaviour.
+2. **Control authentication and payloads.** Switch between raw and JSON bodies, set explicit content types, and configure basic, bearer, or API key authentication before dispatching the call.
+3. **Inspect responses in depth.** Review status metadata, headers, formatted bodies, and size metrics to confirm expectations or identify service defects.
+4. **Track history for handoffs.** Save each execution automatically, replay useful requests, and export response details while collaborating during incidents.
+
+## Operator References
+- [API Checker Operator Guide](./OPERATOR.md)

--- a/toolkits/connectivity/docs/OPERATOR.md
+++ b/toolkits/connectivity/docs/OPERATOR.md
@@ -1,0 +1,32 @@
+# Bulk Connectivity Checker Operator Guide
+
+Use this guide to manage connectivity catalogs, exercise probe workflows, and interpret job output during incidents.
+
+## Maintain Target Catalogs
+1. Navigate to **Toolkits → Connectivity Checks**.
+2. Use **New Target** to define a fleet:
+   - Give the group a descriptive name and context-rich description.
+   - Add each host as a hostname or IP. Attach one or more ports per host and pick the protocol (`tcp` or `udp`).
+   - Save changes. The catalog lists endpoint counts and last-updated timestamps so you can audit ownership.
+3. Edit a target to add or remove hosts. Delete unused targets to keep the catalog current.
+
+## Preview Probe Runs
+- Open a target and choose **Preview Check** when you need a latency estimate before committing to a scheduled job.
+- Set the repetition count to mirror your planned run. The preview returns reachability summaries immediately and does not create job records.
+- Investigate failures directly from the preview panel: each result includes host, port, protocol, and failure message.
+
+## Execute Bulk Jobs
+1. From a target, choose **Run Connectivity Check**.
+2. Specify the number of repetitions to increase confidence in the results. Each repetition performs a full sweep of all endpoints.
+3. Submit the job. The worker queue records a log entry and begins processing; monitor progress from the job panel or the global **Jobs** page.
+4. Job logs stream per-endpoint status with ✅/❌ markers. Cancel a job from the log viewer if the situation stabilises.
+5. When complete, download the summary to share with incident channels or attach to remediation tickets.
+
+## Ad-hoc Spot Checks
+- Use **Ad-hoc Check** for one-off investigations that do not warrant catalog entries.
+- Provide a temporary host/port list and optional repetitions. Results render inline for quick validation.
+
+## Operational Tips
+- Schedule follow-up jobs after remediation to confirm reachability is restored.
+- For persistent failures, capture the latency and error message from the job logs to hand off to the owning team.
+- Keep port lists lean; large TCP sweeps slow down worker throughput and inflate alert noise.

--- a/toolkits/connectivity/docs/README.md
+++ b/toolkits/connectivity/docs/README.md
@@ -1,0 +1,13 @@
+# Bulk Connectivity Checker Overview
+
+## Purpose
+The Bulk Connectivity Checker orchestrates large batches of reachability probes so operators can validate port access, spot regional failures, and launch remediation workflows across entire host fleets.
+
+## Primary Workflows
+1. **Curate connectivity targets.** Group hosts and ports into reusable target definitions that document probe intent and act as the source of truth for recurring checks.
+2. **Preview probe runs.** Dry-run a target to estimate expected failures and latency before scheduling a job, helping tune repetition counts and confirming the catalog is accurate.
+3. **Execute and monitor jobs.** Dispatch bulk probe operations to the worker queue, then watch job logs for per-endpoint success, failure details, and cancellation status.
+4. **Run ad-hoc spot checks.** Trigger one-off connectivity tests against custom endpoint lists when investigating incidents or validating remediation.
+
+## Operator References
+- [Bulk Connectivity Checker Operator Guide](./OPERATOR.md)

--- a/toolkits/latency_sleuth/docs/README.md
+++ b/toolkits/latency_sleuth/docs/README.md
@@ -1,0 +1,12 @@
+# Latency Sleuth Overview
+
+## Purpose
+Latency Sleuth helps SREs model end-to-end web latency with synthetic probes so they can validate SLAs, surface performance drift, and rehearse incident response before changes reach production.
+
+## Primary Workflows
+1. **Author probe templates.** Define the target URL, method, cadence, SLA thresholds, and notification rules for each synthetic check. Tag templates with service identifiers so dashboards roll up coverage correctly.
+2. **Preview and tune thresholds.** Use the built-in heatmaps and scheduling panels to watch how probes behave over time, adjusting alert windows until they reflect real user expectations.
+3. **Monitor executions and alerts.** Follow live job logs for in-flight probes, review breach streaks, and confirm notifications reach Slack, PagerDuty, or webhook targets as configured.
+
+## Operator References
+- [Latency Sleuth Operator Guide](./OPERATOR.md)


### PR DESCRIPTION
## Summary
- add README overviews for the Latency Sleuth, Bulk Connectivity Checker, and API Checker toolkits
- document common operator workflows for connectivity and API Checker alongside the existing guides
- link each overview to the corresponding operator guide so automation can surface deep-dive docs

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_b_68d10966abc48328b43e1db684614190