### PR TITLE
docs: document automated toolkit packaging workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ SRE Toolbox is a modular operations cockpit for site reliability teams. The ligh
 - `backend/` – FastAPI API, Celery worker entrypoints, Alembic migrations, and the toolkit loader.
 - `frontend/` – React + Vite shell and operator docs under `frontend/documentation/`.
 - `toolkit_runtime/` – Shared runtime helpers injected into toolkit bundles (Redis, Celery, API client primitives).
-- `toolkits/` – Bundled reference toolkits and packaging utilities (`scripts/package_toolkit.py`, `package_all_toolkits.py`).
+- `toolkits/` – Bundled reference toolkits plus the packaging utilities CI uses (`scripts/package_toolkit.py`, `package_all_toolkits.py`).
 - `config/` – Vault configuration (`config/vault/local.hcl`) and sample auth provider manifests.
 - `docker/` – Container entrypoints, including the Vault init/unseal helper.
 - `docs/` – Engineering guides (coding standards, toolkit authoring, runtime architecture).
@@ -174,7 +174,7 @@ Additional provider-specific settings (OIDC, LDAP/AD) can be injected via `AUTH_
 - **Jobs** – pollable list with inline log streaming and cancellation that propagates to Celery.
 - **Toolkits index** – view metadata, enable/disable toolkits, and open toolkit documentation.
 - **Toolkit routes** – `/toolkits/:slug/*` renders toolkit-provided React layouts or a friendly placeholder when no UI bundle ships.
-- **Administration → Toolkits** – browse the Overview (getting started guidance + installed toolkit controls), review the Community Catalog of <https://sxmxc.github.io/ideal-octo-engine>, or upload bundles from the Upload page. Installs stream from <https://raw.githubusercontent.com/sxmxc/ideal-octo-engine/main/catalog/toolkits.json>; override it via `TOOLKIT_CATALOG_URL` or the catalog URL form (superuser only).
+- **Administration → Toolkits** – browse the Overview (getting started guidance + installed toolkit controls), review the Community Catalog of <https://sxmxc.github.io/ideal-octo-engine>, or upload bundles from the Upload page. Installers typically use the artifacts emitted by the Release workflow. Installs stream from <https://raw.githubusercontent.com/sxmxc/ideal-octo-engine/main/catalog/toolkits.json>; override it via `TOOLKIT_CATALOG_URL` or the catalog URL form (superuser only).
 - **Administration → Toolbox settings** – adjust framework-specific options such as the community catalog override used for discovery installs.
 - **Administration → Users** – invite local users, assign roles, or import external identities.
 - **Administration → Toolbox settings → Auth** – configure local, OIDC, LDAP, or Active Directory providers without redeploying.
@@ -199,7 +199,7 @@ These bundles mirror the format expected by the runtime, so you can use them as 
 2. **Backend module** – expose a FastAPI `APIRouter` (default attribute `router`) that is mounted under `/toolkits/<slug>`.
 3. **Worker module** – export a callable (default `register`) to register Celery tasks like `<slug>.<operation>`. The runtime injects the shared Celery app and a `register_handler` helper when requested.
 4. **Frontend bundle (optional)** – ship an ESM entry at `frontend/dist/index.js`. During development, toolkits can point to `frontend/index.tsx` so Vite provides hot reloads. At runtime the App Shell injects `React`, `React Router`, and `apiFetch` through `window.__SRE_TOOLKIT_RUNTIME`.
-5. **Package** – run `python toolkits/scripts/package_toolkit.py <path>` to validate the manifest and emit `<slug>_toolkit.zip`. Upload the archive from Admin → Toolkits or via `POST /toolkits/install`. The installer rejects archives containing absolute paths, drive letters, parent-directory segments, or symlinks and, once validated, unpacks bundles into `TOOLKIT_STORAGE_DIR/<slug>/` while serving static assets from `/toolkit-assets/<slug>/…`.
+5. **Package** – merge your changes (including fresh build artifacts) into `main`. The Release workflow packages each toolkit and uploads a `toolkit-<slug>` artifact containing `<slug>_toolkit.zip`. Download it from the workflow run (or via `gh run download`) before installing through Admin → Toolkits or `POST /toolkits/install`. The installer rejects archives containing absolute paths, drive letters, parent-directory segments, or symlinks and, once validated, unpacks bundles into `TOOLKIT_STORAGE_DIR/<slug>/` while serving static assets from `/toolkit-assets/<slug>/…`.
 
 Example manifest:
 

--- a/docs/toolbox-architecture.md
+++ b/docs/toolbox-architecture.md
@@ -35,7 +35,7 @@ All three share a common domain model (PostgreSQL or SQLite), a Redis-backed eve
 
 ## Toolkit runtime contract
 
-1. **Packaging** – Toolkits ship as zip archives containing `toolkit.json` plus optional backend, worker, and frontend modules. Scripts under `toolkits/scripts/` help validate and package bundles.
+1. **Packaging** – Toolkits ship as zip archives containing `toolkit.json` plus optional backend, worker, and frontend modules. The Release workflow invokes the helpers under `toolkits/scripts/` to validate manifests and build bundles automatically whenever `main` is updated.
 2. **Installation** – Operators upload archives through Admin → Toolkits or `POST /toolkits/install`. The installer unpacks bundles into `TOOLKIT_STORAGE_DIR/<slug>/`.
 3. **Activation** – On startup (or after an install event) the loader imports backend routers and worker registration hooks, then advertises dashboard cards and frontends to the App Shell.
 4. **Execution** – API endpoints enqueue jobs to Celery, which pulls runtime dependencies (database, Redis, external APIs) defined by the toolkit.

--- a/docs/toolkit-authoring/overview.md
+++ b/docs/toolkit-authoring/overview.md
@@ -7,7 +7,7 @@ Use this guide as the starting point for building SRE Toolbox toolkits. It conne
 - **Scaffold** – follow the baseline directory structure (`toolkit.json`, `backend/`, `worker/`, `frontend/`).
 - **Develop** – iterate locally with the Toolbox stack (`npm run dev`, `uvicorn`, `celery`) so your toolkit interacts with live APIs.
 - **Document** – add guides to `frontend/documentation` so the in-app knowledge base reflects new capabilities.
-- **Package & Release** – bundle with `toolkits/scripts/package_toolkit.py` and publish the resulting `<slug>_toolkit.zip` via Admin → Toolkits.
+- **Build & Release** – compile toolkit assets (for example, `frontend/dist/index.js`) and push the changes through the repository release workflow. CI packages the bundle automatically—no manual zip step required.
 
 ## Key Runtime Contracts
 - `AppShell.tsx` injects `React`, `react-router-dom`, and `apiFetch` into `window.__SRE_TOOLKIT_RUNTIME`; avoid bundling those dependencies yourself.

--- a/docs/toolkit-authoring/testing-and-release.md
+++ b/docs/toolkit-authoring/testing-and-release.md
@@ -15,12 +15,13 @@ Follow this sequence before publishing a toolkit bundle so operators receive a r
 - Validate documentation links in your toolkit dashboard cards open the intended guides in `/documentation/*`.
 
 ## Packaging & Distribution
-- Run `python toolkits/scripts/package_toolkit.py <path>` to build `<slug>_toolkit.zip`.
-- Verify the slug in `toolkit.json` uses only lowercase letters, numbers, hyphen (`-`), or underscore (`_`); packaging fails fast when the allowlist is violated.
-- Include the generated archive and release notes in your artifact store (GitHub Releases, internal registry, etc.).
+- Build the frontend bundle (when applicable) so artifacts such as `frontend/dist/index.js` or custom `frontend.entry` targets exist before you commit.
+- Verify the slug in `toolkit.json` uses only lowercase letters, numbers, hyphen (`-`), or underscore (`_`); the release workflow fails quickly when the allowlist is violated.
 - Bump the toolkit version in `toolkit.json` and include a changelog entry summarising major changes and migration steps.
-- Ensure the archive does not contain absolute paths, drive letters, parent-directory segments, or symlinks—uploads are rejected when these appear to prevent directory traversal during install.
-- Keep the archive within the enforced limits (`TOOLKIT_UPLOAD_MAX_BYTES` compressed, `TOOLKIT_BUNDLE_MAX_BYTES` total extracted, `TOOLKIT_BUNDLE_MAX_FILE_BYTES` per file) so installs cannot inflate into zip bombs.
+- Merge your branch (with built assets committed) into `main`. The **Release** GitHub Actions workflow runs on every push to `main`, invokes `toolkits/scripts/package_all_toolkits.py`, and uploads a `toolkit-<slug>` artifact containing `<slug>_toolkit.zip`.
+- Monitor the workflow under **Actions → Release**. You can download artifacts directly from the run summary or via `gh run download --repo <org>/<repo> --name toolkit-<slug>` once the `Package Toolkit` job succeeds.
+- Share the downloaded archive alongside release notes in your preferred artifact store, or hand it to the operations team for installation.
+- Ensure the archive remains within the enforced limits (`TOOLKIT_UPLOAD_MAX_BYTES` compressed, `TOOLKIT_BUNDLE_MAX_BYTES` total extracted, `TOOLKIT_BUNDLE_MAX_FILE_BYTES` per file). The packaging job fails if these limits are exceeded or if prohibited paths (absolute, parent-directory segments, symlinks) appear.
 
 ## Rollback Strategy
 - Keep the previous release bundle available so operators can reinstall quickly if issues arise.

--- a/frontend/documentation/examples-basic-toolkit.md
+++ b/frontend/documentation/examples-basic-toolkit.md
@@ -68,8 +68,8 @@ export default function StatusToolkit() {
 ## Deploying
 
 1. Build the frontend bundle so `frontend/dist/index.js` exists (for example, run your bundler or `npm run build`).
-2. Zip the directory.
-3. Upload via **Administration → Toolkits**.
+2. Commit the generated assets and merge into `main`. The Release workflow publishes a `toolkit-status` artifact that contains `status_toolkit.zip`.
+3. Download the artifact from the workflow run (or via `gh run download --repo <org>/<repo> --name toolkit-status`) and upload the archive via **Administration → Toolkits**.
 4. Enable the toolkit and browse to `/toolkits/status` to view the UI panel.
 
 Extend the example by adding worker jobs that poll upstream systems or by styling the UI using the guidance in [Toolkit UI Guide](toolkit-ui).

--- a/frontend/documentation/toolbox-administration.md
+++ b/frontend/documentation/toolbox-administration.md
@@ -15,11 +15,11 @@ Use this guide to run the SRE Toolbox day to day. It covers the management scree
 3. Toggle the switch to enable or disable it. The change propagates immediately to the API and worker. If a toolkit fails to load, the UI displays the error surfaced by the worker import hook.
 4. Use the "Open documentation" link to verify that operator guidance exists in `frontend/documentation`.
 
-## Uploading a new toolkit
+## Deploying a new toolkit build
 
-1. Package the bundle using `toolkits/scripts/package_toolkit.py` (see [Toolkit Build Workflow](toolkit-build)).
-2. Open **Administration → Toolkits → Upload bundle**.
-3. Provide the `.zip` file. The backend validates the slug, manifest, and file shapes before extracting the archive to `TOOLKIT_STORAGE_DIR`.
+1. Confirm the author merged their changes and that the **Release** workflow produced a fresh `toolkit-<slug>` artifact (see [Toolkit Build Workflow](toolkit-build) for authoring guidance).
+2. Download `<slug>_toolkit.zip` from the workflow run or via `gh run download --repo <org>/<repo> --name toolkit-<slug>`.
+3. Open **Administration → Toolkits → Upload bundle** and provide the downloaded archive. The backend validates the slug, manifest, and file shapes before extracting the toolkit to `TOOLKIT_STORAGE_DIR`.
 4. Enable the toolkit and confirm it registers a dashboard card or UI entry. If the worker reports an import error, check the worker logs and ensure the bundle paths match the manifest.
 
 ## Monitoring jobs

--- a/frontend/documentation/toolkit-build.md
+++ b/frontend/documentation/toolkit-build.md
@@ -23,22 +23,22 @@ my-toolkit/
 
 If your toolkit ships a UI, generate an ESM bundle at the path referenced by `toolkit.json → frontend.entry` (default: `frontend/dist/index.js`). Toolkits can use any build tool as long as the output targets modern browsers and keeps `react`, `react-dom`, and `react-router-dom` external—the shell provides them at runtime.
 
-## 3. Validate and package
+## 3. Trigger automated packaging
 
-Use the packaging utility checked into this repo to ensure required files exist before you distribute the bundle:
+The repository's **Release** workflow runs on every push to `main` and packages toolkits for you—no local zip step is required.
 
-```bash
-python toolkits/scripts/package_toolkit.py /path/to/my-toolkit
-```
+1. Commit the toolkit changes (including built assets such as `frontend/dist/index.js`) and open a pull request.
+2. After approval, merge into `main`. The Release workflow detects every `toolkit.json` and runs `toolkits/scripts/package_all_toolkits.py` to build `<slug>_toolkit.zip` archives.
+3. Monitor the run under **GitHub → Actions → Release**. Each toolkit appears as a `Package Toolkit (<slug>)` job.
+4. Download the resulting artifact named `toolkit-<slug>` from the workflow summary, or fetch it via the CLI:
 
-The script performs the following checks:
+   ```bash
+   gh run download --repo <org>/<repo> --name toolkit-<slug> --dir dist
+   ```
 
-- `toolkit.json` is present and valid JSON.
-- Files referenced by `frontend.entry` and `frontend.source_entry` exist.
-- The default `frontend/dist/index.js` is present when no `frontend.entry` is declared.
-- Ignores development build artefacts such as `node_modules/` and `.DS_Store`.
+5. Share the downloaded archive with operators or upload it through **Administration → Toolkits** once you're ready to deploy.
 
-On success it creates `<slug>_toolkit.zip` alongside the toolkit directory (override with `--output`). Distribute that archive to operators or upload it through **Administration → Toolkits**.
+The workflow enforces the same validations as the historical helper script: manifest syntax, slug allowlists, required frontend entries, and filesystem safety guards.
 
 ## 4. Ship documentation
 
@@ -48,6 +48,6 @@ Include markdown in `frontend/documentation` that references your toolkit so it 
 
 - Keep frontend bundles small: lazy-load heavy pages or embed them behind feature flags inside your toolkit.
 - Version the toolkit directory with Git so you can reproduce releases and build deterministic archives.
-- Automate packaging as part of CI by invoking the Python helper and uploading the resulting zip to your artifact store.
+- Use the Release workflow artifacts as your source of truth—archive them in your artifact store if you need longer retention than GitHub Actions provides.
 
 Return to the [Toolkit](toolkit) overview for more information about runtime expectations.

--- a/frontend/documentation/toolkit.md
+++ b/frontend/documentation/toolkit.md
@@ -43,10 +43,11 @@ See the [UI](ui) reference for a full tour. Highlights:
 
 Follow the [Toolkit Build Workflow](toolkit-build) for a detailed walkthrough. In short:
 
-1. Build the frontend bundle (if applicable) so it matches `toolkit.json → frontend.entry`.
-2. Run `python toolkits/scripts/package_toolkit.py <path>` to validate required files—including the lowercase slug allowlist—and generate a release archive.
-3. Upload the resulting `.zip` via `/toolkits/install` or the Admin → Toolkits UI.
-4. Enable the toolkit to register routes, worker tasks, and frontend contributions.
+1. Build the frontend bundle (if applicable) so it matches `toolkit.json → frontend.entry`—for example, ensure `frontend/dist/index.js` exists.
+2. Commit the generated assets alongside your code changes and merge into `main`.
+3. Watch the **Release** workflow under GitHub Actions. It packages each toolkit automatically and publishes a `toolkit-<slug>` artifact containing `<slug>_toolkit.zip`.
+4. Download the artifact from the workflow run (or via `gh run download`) and install it through `/toolkits/install` or the Admin → Toolkits UI.
+5. Enable the toolkit to register routes, worker tasks, and frontend contributions once the new bundle is uploaded.
 
 ## Suggested Workflow
 

--- a/toolkits/README.md
+++ b/toolkits/README.md
@@ -4,20 +4,13 @@ This directory contains bundled toolkits and utility scripts for packaging your 
 
 ## Packaging a toolkit
 
-Use the helper script to validate a toolkit directory and generate a distributable `.zip`:
+The repository's **Release** workflow packages toolkits automatically on every push to `main`:
 
-```bash
-python toolkits/scripts/package_toolkit.py toolkits/bundled/zabbix
-```
+1. Build any frontend bundles so files such as `frontend/dist/index.js` exist.
+2. Commit the assets, open a pull request, and merge into `main`.
+3. Download the `toolkit-<slug>` artifact produced by the Release workflow (either from the run summary or via `gh run download`).
 
-The script checks that:
-
-- `toolkit.json` exists and declares a slug.
-- The slug only contains lowercase letters, numbers, hyphen (`-`), or underscore (`_`).
-- Files referenced by `frontend.entry` / `frontend.source_entry` are present.
-- Default `frontend/dist/index.js` is included when no entry is specified.
-
-By default the archive is written next to the toolkit as `<slug>_toolkit.zip`. Supply `--output` to place it elsewhere and `--force` to overwrite existing files.
+The workflow runs `toolkits/scripts/package_all_toolkits.py` internally, enforcing manifest validation, slug allowlists, and filesystem safety rules. The standalone helper remains available for local smoke tests, but day-to-day releases should rely on CI.
 
 ## Bundled examples
 

--- a/toolkits/api_checker/BUILDING.md
+++ b/toolkits/api_checker/BUILDING.md
@@ -17,11 +17,7 @@
      --loader:.tsx=tsx
    ```
 
-2. **Package the toolkit** once the bundle is generated:
+2. **Trigger packaging via CI**:
 
-   ```bash
-   cd ../toolkits/scripts
-   python package_toolkit.py ../api_checker
-   ```
-
-   A distributable archive named `api-checker_toolkit.zip` will be created alongside the toolkit directory.
+   - Commit the updated bundle to a branch, open a pull request, and merge into `main`.
+   - The Release workflow packages the toolkit automatically. Download the `toolkit-api-checker` artifact (which contains `api-checker_toolkit.zip`) from the workflow run or fetch it via `gh run download --repo <org>/<repo> --name toolkit-api-checker`.

--- a/toolkits/bundled/regex/BUILDING.md
+++ b/toolkits/bundled/regex/BUILDING.md
@@ -1,10 +1,6 @@
 # Building the Regex Toolkit
 
 1. Confirm `frontend/dist/index.js` is up to date. Bundle it from `frontend/index.tsx` while leaving `react`, `react-dom`, and `react-router-dom` external.
-2. Package the toolkit with the helper script:
-
-```bash
-python ../../scripts/package_toolkit.py .
-```
-
-3. Install the resulting `regex_toolkit.zip` through **Administration → Toolkits** or the `/toolkits/install` API.
+2. Commit the refreshed assets, merge into `main`, and let the Release workflow build the distribution bundle.
+3. Download the `toolkit-regex` artifact (containing `regex_toolkit.zip`) from the workflow run or via `gh run download --repo <org>/<repo> --name toolkit-regex`.
+4. Install the downloaded archive through **Administration → Toolkits** or the `/toolkits/install` API.

--- a/toolkits/bundled/toolbox_health/BUILDING.md
+++ b/toolkits/bundled/toolbox_health/BUILDING.md
@@ -16,11 +16,7 @@
      --loader:.tsx=tsx
    ```
 
-2. Package the toolkit using the helper script:
-
-   ```bash
-   python ../../scripts/package_toolkit.py .
-   ```
-
-3. Upload the generated `toolbox-health_toolkit.zip` through **Administration → Toolkits** or via the `/toolkits/install` API.
+2. Commit the refreshed assets, merge into `main`, and let the Release workflow handle packaging.
+3. Download the `toolkit-toolbox-health` artifact (containing `toolbox-health_toolkit.zip`) from the workflow run or via `gh run download --repo <org>/<repo> --name toolkit-toolbox-health`.
+4. Upload the downloaded archive through **Administration → Toolkits** or via the `/toolkits/install` API.
 

--- a/toolkits/bundled/zabbix/BUILDING.md
+++ b/toolkits/bundled/zabbix/BUILDING.md
@@ -2,10 +2,6 @@
 
 1. Ensure the frontend bundle exists at `frontend/dist/index.js`.
    - Build from `frontend/index.tsx` with your preferred tooling. Keep `react`, `react-dom`, and `react-router-dom` external so the Toolbox shell provides them at runtime.
-2. Run the packaging helper to create the release archive:
-
-```bash
-python ../../scripts/package_toolkit.py .
-```
-
-3. Upload the generated `zabbix_toolkit.zip` via **Administration → Toolkits** or the `/toolkits/install` API.
+2. Commit the refreshed bundle, merge into `main`, and allow the Release workflow to create the archive.
+3. Download the `toolkit-zabbix` artifact (containing `zabbix_toolkit.zip`) from the workflow run or via `gh run download --repo <org>/<repo> --name toolkit-zabbix`.
+4. Upload the downloaded archive via **Administration → Toolkits** or the `/toolkits/install` API.

--- a/toolkits/connectivity/BUILDING.md
+++ b/toolkits/connectivity/BUILDING.md
@@ -17,11 +17,7 @@
      --loader:.tsx=tsx
    ```
 
-2. Package the toolkit:
+2. Trigger packaging in CI:
 
-   ```bash
-   cd ../toolkits/scripts
-   python package_toolkit.py ../connectivity
-   ```
-
-   This produces `connectivity_toolkit.zip` alongside the toolkit directory.
+   - Commit the refreshed bundle to a branch, submit a pull request, and merge into `main`.
+   - The Release workflow emits a `toolkit-connectivity` artifact that contains `connectivity_toolkit.zip`. Download it from the workflow run or via `gh run download --repo <org>/<repo> --name toolkit-connectivity`.

--- a/toolkits/latency_sleuth/BUILDING.md
+++ b/toolkits/latency_sleuth/BUILDING.md
@@ -1,15 +1,14 @@
 # Building the Latency Sleuth Toolkit
 
-Latency Sleuth ships as an optional toolkit bundle. Use the provided helper script to verify the manifest and produce a distributable archive.
+Latency Sleuth ships as an optional toolkit bundle. Build the frontend, commit the assets, and let CI produce the distributable archive.
 
-```bash
-python toolkits/scripts/package_toolkit.py toolkits/latency_sleuth
-```
-
-The command emits `latency-sleuth_toolkit.zip` alongside the source directory. Upload that archive through **Admin → Toolkits** in the Toolbox UI whenever you want to distribute a release candidate.
+1. Ensure `frontend/dist/index.js` is rebuilt from the latest source.
+2. Commit the changes, open a pull request, and merge into `main`.
+3. Download the `toolkit-latency-sleuth` artifact (containing `latency-sleuth_toolkit.zip`) from the Release workflow run or via `gh run download --repo <org>/<repo> --name toolkit-latency-sleuth`.
 
 ## Release Checklist
 - Update `toolkit.json` with a bumped `version` and `updated_at` timestamp.
 - Regenerate operator documentation after any SLA tuning or alerting workflow changes.
-- Run backend (`pytest`), worker, and frontend (`vitest`) tests from this directory before packaging.
+- Run backend (`pytest`), worker, and frontend (`vitest`) tests from this directory before merging.
+- Confirm the Release workflow succeeded for `toolkit-latency-sleuth` and share the downloaded archive with operators.
 - Capture noteworthy changes in your release notes so operators understand behavioural differences.

--- a/toolkits/latency_sleuth/docs/OPERATOR.md
+++ b/toolkits/latency_sleuth/docs/OPERATOR.md
@@ -50,8 +50,8 @@ after restarts. Monitor upcoming executions in the **Scheduling** panel within t
    pytest toolkits/latency_sleuth/tests
    npm --prefix frontend test -- --run toolkits/latency_sleuth/frontend
    ```
-2. Package the bundle using `toolkits/scripts/package_toolkit.py`.
-3. Attach `latency-sleuth_toolkit.zip` and updated release notes to your distribution channel.
+2. Merge the changes into `main` and confirm the Release workflow produced the `toolkit-latency-sleuth` artifact.
+3. Attach the downloaded `latency-sleuth_toolkit.zip` and updated release notes to your distribution channel.
 4. After installation, confirm the dashboard card links to `/toolkits/latency-sleuth`.
 
 For troubleshooting, inspect Celery worker logs for `latency-sleuth.run_probe` entries and check Redis keys prefixed with


### PR DESCRIPTION
## Summary
- replace toolkit authoring guidance to highlight the CI-based packaging workflow and required build artifacts
- refresh user-facing docs and toolkit BUILDING guides to explain how to trigger, monitor, and retrieve Release workflow artifacts
- update repository references so administrators and operators follow the automated bundling pipeline

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_b_68d10de976748328a85942d00bc429a2