### PR TITLE
feat: support dotenv interpolation in bootstrap helper

### DIFF
--- a/ai/state/journal.md
+++ b/ai/state/journal.md
@@ -70,3 +70,17 @@ Track Codex sessions chronologically. Each entry should capture what was attempt
 - Updated bundle resolution to treat GitHub raw manifests as catalog descriptors, prefer `github.io` bundle URLs, and degrade to the manifest directory when needed (`backend/app/routes/toolkits.py`) with regression coverage for both success and fallback flows (`backend/tests/test_toolkits_catalog.py`).
 - Hardened bundle writes to tolerate cross-device rename errors encountered in Docker deployments by copying temp files when needed, taught the resolver to try `.zip` variants for extensionless bundle paths, and added coverage (including zip signature detection) to ensure HTML responses from WSGI apps fall through to zip bundles (`backend/app/routes/toolkits.py`, `backend/tests/test_toolkits_catalog.py`).
 - Documented the published-site preference for curators (`docs/toolbox-architecture.md`) and attempted the targeted pytest run, which still fails locally because `httpx` is missing from the harness environment.
+
+## 2025-09-22 Bootstrap dotenv parser
+- Captured bootstrap regression caused by unquoted `.env` values by adding pytest coverage for a new parser (`backend/tests/test_dotenv_loader.py`).
+- Built `app.core.dotenv_loader` to accept unquoted strings, inline comments, and `export` prefixes, emitting JSON-escaped exports for shell consumption (`backend/app/core/dotenv_loader.py`).
+- Updated `bootstrap-stack.sh` to rely on the parser instead of `source` so `.env` entries like `APP_NAME=SRE Toolbox` no longer break bootstrap, keeping Vault detection and overrides intact.
+- Logged completion under TODO `bootstrap-dotenv-parser` and recorded progress with a session counter increment.
+- Ran `pytest backend/tests/test_dotenv_loader.py` to validate the parser end-to-end.
+
+## 2025-09-24 Dotenv interpolation
+- Added regression tests covering ${VAR} interpolation, late definitions, cycles, and escaped literals for the bootstrap parser (`backend/tests/test_dotenv_loader.py`).
+- Extended `app.core.dotenv_loader` with ordered dependency resolution so variables can reference previously or subsequently defined values while rejecting undefined keys and cycles (`backend/app/core/dotenv_loader.py`).
+- Verified the bootstrap helper remains compatible by rerunning the targeted pytest suite (`pytest backend/tests/test_dotenv_loader.py`).
+- Updated repository automation notes to capture the interpolation enhancement and logged progress for the session (`docs/TODO.yaml`, `ai/state/progress.json`).
+- Refactored `bootstrap-stack.sh` Vault helpers to parse JSON via `python3 -c` here-strings so command substitutions no longer feed empty input when combining pipes and heredocs, eliminating the `JSONDecodeError` seen during `vault status` and `operator init` probes.

--- a/ai/state/progress.json
+++ b/ai/state/progress.json
@@ -1,10 +1,20 @@
 {
   "version": 1,
-  "last_updated": "2025-09-22T19:55:00Z",
-  "session_counter": 12,
+  "last_updated": "2025-09-24T03:43:49Z",
+  "session_counter": 14,
   "active_task": null,
-  "last_task_id": "community-bundle-resolution",
+  "last_task_id": "bootstrap-dotenv-parser",
   "recent_updates": [
+    {
+      "task_id": "bootstrap-dotenv-parser",
+      "status": "done",
+      "summary": "Enabled ${VAR} interpolation in the dotenv parser so bootstrap-stack.sh can derive DATABASE_URL credentials from POSTGRES_* once, and refactored Vault status parsing to avoid JSONDecodeError when probing docker exec output."
+    },
+    {
+      "task_id": "bootstrap-dotenv-parser",
+      "status": "done",
+      "summary": "Added a python-backed dotenv parser with pytest coverage and taught bootstrap-stack.sh to load .env values containing spaces safely."
+    },
     {
       "task_id": "community-bundle-resolution",
       "status": "done",

--- a/backend/app/core/dotenv_loader.py
+++ b/backend/app/core/dotenv_loader.py
@@ -55,10 +55,12 @@ def _parse_line(raw_line: str, line_no: int) -> Tuple[str, str] | None:
             tokens = shlex.split(value, posix=True)
         except ValueError as exc:
             raise DotenvError(f"Line {line_no}: {exc}") from exc
-        if len(tokens) != 1:
-            raise DotenvError(
-                f"Line {line_no}: unexpected tokens after quoted value"
-            )
+        if len(tokens) > 1:
+            comment = tokens[1]
+            if comment != "#" and not comment.startswith("#"):
+                raise DotenvError(
+                    f"Line {line_no}: unexpected tokens after quoted value"
+                )
         return key, tokens[0]
 
     cleaned = _strip_comment(value)

--- a/backend/app/core/dotenv_loader.py
+++ b/backend/app/core/dotenv_loader.py
@@ -1,0 +1,132 @@
+"""Minimal dotenv parser for shell consumption.
+
+The bootstrap helper reads `.env` files to pick up overrides. When
+operators copy `.env.example` the file often includes values with spaces,
+which `bash` rejects unless quoted. The parser below accepts the common
+subset we use across the repository and surfaces helpful errors when a
+line cannot be parsed.
+"""
+from __future__ import annotations
+
+import json
+import re
+import shlex
+import sys
+from collections import OrderedDict
+from pathlib import Path
+from typing import Iterable, Iterator, Tuple
+
+_NAME_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_VAR_PATTERN = re.compile(r"(?<!\\)\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
+
+
+class DotenvError(ValueError):
+    """Raised when a .env file contains an invalid entry."""
+
+
+def _strip_comment(value: str) -> str:
+    """Remove inline comments from an unquoted value."""
+    for index, char in enumerate(value):
+        if char == "#" and (index == 0 or value[index - 1].isspace()):
+            return value[:index].rstrip()
+    return value.rstrip()
+
+
+def _parse_line(raw_line: str, line_no: int) -> Tuple[str, str] | None:
+    line = raw_line.strip()
+    if not line or line.startswith("#"):
+        return None
+    if line.startswith("export "):
+        line = line[len("export "):].lstrip()
+
+    if "=" not in line:
+        raise DotenvError(f"Line {line_no}: expected KEY=VALUE assignment")
+
+    key_part, value_part = line.split("=", 1)
+    key = key_part.strip()
+    if not _NAME_PATTERN.match(key):
+        raise DotenvError(f"Line {line_no}: invalid variable name '{key}'")
+
+    value = value_part.strip()
+    if not value:
+        return key, ""
+    if value[0] in {'"', "'"}:
+        try:
+            tokens = shlex.split(value, posix=True)
+        except ValueError as exc:
+            raise DotenvError(f"Line {line_no}: {exc}") from exc
+        if len(tokens) != 1:
+            raise DotenvError(
+                f"Line {line_no}: unexpected tokens after quoted value"
+            )
+        return key, tokens[0]
+
+    cleaned = _strip_comment(value)
+    return key, cleaned.strip()
+
+def _resolve_interpolations(values: "OrderedDict[str, str]") -> "OrderedDict[str, str]":
+    resolved: "OrderedDict[str, str]" = OrderedDict()
+    stack: set[str] = set()
+
+    def resolve(key: str) -> str:
+        if key in resolved:
+            return resolved[key]
+        if key not in values:
+            raise DotenvError(f"Undefined variable '{key}' referenced during interpolation")
+        if key in stack:
+            cycle = " -> ".join(list(stack) + [key])
+            raise DotenvError(f"Circular interpolation reference detected: {cycle}")
+        stack.add(key)
+        raw_value = values[key]
+        try:
+            def replacer(match: re.Match[str]) -> str:
+                ref = match.group(1)
+                return resolve(ref)
+
+            result = _VAR_PATTERN.sub(replacer, raw_value)
+        finally:
+            stack.discard(key)
+        resolved_value = result.replace(r"\${", "${")
+        resolved[key] = resolved_value
+        return resolved_value
+
+    for key in values:
+        resolve(key)
+    return resolved
+
+def parse_env_file(path: Path | str) -> "OrderedDict[str, str]":
+    """Parse a dotenv file and return an ordered mapping of assignments."""
+    dotenv_path = Path(path)
+    data: "OrderedDict[str, str]" = OrderedDict()
+    with dotenv_path.open("r", encoding="utf-8") as handle:
+        for line_no, raw_line in enumerate(handle, start=1):
+            parsed = _parse_line(raw_line.rstrip("\r\n"), line_no)
+            if parsed is None:
+                continue
+            key, value = parsed
+            data[key] = value
+    return _resolve_interpolations(data)
+
+
+def _format_exports(items: Iterable[Tuple[str, str]]) -> Iterator[str]:
+    for key, value in items:
+        yield f"export {key}={json.dumps(value)}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = argv if argv is not None else sys.argv[1:]
+    env_path = Path(args[0]) if args else Path(".env")
+    try:
+        data = parse_env_file(env_path)
+    except FileNotFoundError:
+        return 0
+    except DotenvError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    for line in _format_exports(data.items()):
+        print(line)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/test_dotenv_loader.py
+++ b/backend/tests/test_dotenv_loader.py
@@ -1,0 +1,88 @@
+import pytest
+
+from app.core import dotenv_loader
+
+
+def write_env(tmp_path, content):
+    path = tmp_path / ".env"
+    path.write_text(content)
+    return path
+
+
+def write_env_lines(tmp_path, lines):
+    return write_env(tmp_path, "\n".join([*lines, ""]))
+
+
+def test_parse_unquoted_value_with_spaces(tmp_path):
+    env_path = write_env(tmp_path, "APP_NAME=SRE Toolbox\n")
+    data = dotenv_loader.parse_env_file(env_path)
+    assert data["APP_NAME"] == "SRE Toolbox"
+
+
+def test_parse_trims_inline_comment(tmp_path):
+    env_path = write_env(tmp_path, "LOG_LEVEL=INFO # comment\n")
+    data = dotenv_loader.parse_env_file(env_path)
+    assert data["LOG_LEVEL"] == "INFO"
+
+
+def test_parse_preserves_hash_inside_quotes(tmp_path):
+    env_path = write_env(tmp_path, 'APP_NAME="SRE Toolbox #1"\n')
+    data = dotenv_loader.parse_env_file(env_path)
+    assert data["APP_NAME"] == "SRE Toolbox #1"
+
+
+def test_parse_supports_export_prefix(tmp_path):
+    env_path = write_env(tmp_path, "export REDIS_URL=redis://redis:6379/0\n")
+    data = dotenv_loader.parse_env_file(env_path)
+    assert data["REDIS_URL"] == "redis://redis:6379/0"
+
+
+def test_invalid_line_raises(tmp_path):
+    env_path = write_env(tmp_path, "Toolbox version\n")
+    with pytest.raises(dotenv_loader.DotenvError):
+        dotenv_loader.parse_env_file(env_path)
+
+
+def test_parse_interpolates_references(tmp_path):
+    env_path = write_env_lines(tmp_path, [
+        "POSTGRES_USER=toolbox",
+        "POSTGRES_PASSWORD=secret123",
+        "DATABASE_URL=postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/toolbox",
+    ])
+    data = dotenv_loader.parse_env_file(env_path)
+    assert data["DATABASE_URL"] == "postgresql+asyncpg://toolbox:secret123@db:5432/toolbox"
+
+
+def test_parse_interpolation_supports_late_definition(tmp_path):
+    env_path = write_env_lines(tmp_path, [
+        "DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db",
+        "POSTGRES_USER=toolbox",
+        "POSTGRES_PASSWORD=secret",
+    ])
+    data = dotenv_loader.parse_env_file(env_path)
+    assert data["DATABASE_URL"] == "postgresql://toolbox:secret@db"
+
+
+def test_parse_interpolation_raises_on_unknown_key(tmp_path):
+    env_path = write_env_lines(tmp_path, [
+        "DATABASE_URL=postgresql://${MISSING}@db",
+    ])
+    with pytest.raises(dotenv_loader.DotenvError):
+        dotenv_loader.parse_env_file(env_path)
+
+def test_parse_interpolation_detects_cycle(tmp_path):
+    env_path = write_env_lines(tmp_path, [
+        "A=${B}",
+        "B=${A}",
+    ])
+    with pytest.raises(dotenv_loader.DotenvError):
+        dotenv_loader.parse_env_file(env_path)
+
+
+def test_parse_interpolation_preserves_escaped_sequence(tmp_path):
+    env_path = write_env_lines(tmp_path, [
+        r"PASSWORD=\${SECRET}",
+    ])
+    data = dotenv_loader.parse_env_file(env_path)
+    assert data["PASSWORD"] == r"${SECRET}"
+

--- a/backend/tests/test_dotenv_loader.py
+++ b/backend/tests/test_dotenv_loader.py
@@ -31,6 +31,15 @@ def test_parse_preserves_hash_inside_quotes(tmp_path):
     assert data["APP_NAME"] == "SRE Toolbox #1"
 
 
+def test_parse_ignores_comment_after_quoted_value(tmp_path):
+    env_path = write_env(
+        tmp_path,
+        'DATABASE_URL="postgresql://localhost" # local override\n',
+    )
+    data = dotenv_loader.parse_env_file(env_path)
+    assert data["DATABASE_URL"] == "postgresql://localhost"
+
+
 def test_parse_supports_export_prefix(tmp_path):
     env_path = write_env(tmp_path, "export REDIS_URL=redis://redis:6379/0\n")
     data = dotenv_loader.parse_env_file(env_path)

--- a/docs/TODO.yaml
+++ b/docs/TODO.yaml
@@ -211,6 +211,14 @@ areas:
           - "Consider interactive prompts or environment validation in tooling scripts."
           - "2025-09-21: Removing docker-compose defaults and updating docs to require operator-supplied credentials."
           - "2025-09-21: Added bootstrap preflight that rejects placeholder Postgres credentials and refreshed onboarding docs."
+      - id: bootstrap-dotenv-parser
+        title: Allow bootstrap helper to parse .env values with spaces.
+        status: done
+        priority: medium
+        notes:
+          - "2025-09-22: Replaced shell sourcing with a Python parser so unquoted values and inline comments load correctly; pytest coverage guards the parser."
+          - "2025-09-24: Added ${VAR} interpolation support so shared secrets only need to be defined once per .env file."
+
   - id: governance
     title: Governance & planning
     summary: Operational guardrails for community contributions and secret management.


### PR DESCRIPTION
## Summary
- add an ordered dotenv parser with ${VAR} interpolation and regression coverage
- refactor bootstrap-stack.sh to load .env via the parser and parse Vault JSON safely
- document the completed infra-tooling task in TODO/progress/journal records

## Testing
- pytest backend/tests/test_dotenv_loader.py
- ./bootstrap-stack.sh

