### PR TITLE
Implement toolkit version updates and catalog checks

### DIFF
--- a/ai/state/journal.md
+++ b/ai/state/journal.md
@@ -89,3 +89,8 @@ Track Codex sessions chronologically. Each entry should capture what was attempt
 - Added TODO item `toolkit-runtime-docs`, documented the shared runtime in `docs/toolkit-runtime.md`, and linked the guide from runtime architecture, authoring, and repository overviews.
 - Updated progress tracking (`ai/state/progress.json`) and cleared the active task after completion.
 - No tests were required; documentation-only change.
+
+## 2025-09-25 Toolkit update pipeline
+- Persisted manifest versions on install/update so registry + UI can surface semantic versions without touching bundled manifests.
+- Added `/toolkits/updates` API with packaging-based comparison, community catalog polling, and frontend badges for curators.
+- Introduced `/toolkits/{slug}/update` to reuse community installs for upgrades, wired admin UI actions, and refreshed TODO priorities.

--- a/ai/state/progress.json
+++ b/ai/state/progress.json
@@ -1,10 +1,25 @@
 {
   "version": 1,
-  "last_updated": "2025-09-24T05:04:20.406972+00:00",
-  "session_counter": 15,
+  "last_updated": "2025-09-25T00:00:00+00:00",
+  "session_counter": 16,
   "active_task": null,
-  "last_task_id": "toolkit-runtime-docs",
+  "last_task_id": "update-mechanism",
   "recent_updates": [
+    {
+      "task_id": "update-mechanism",
+      "status": "done",
+      "summary": "Added community toolkit update endpoint with manifest version validation, download reuse, and UI integration for one-click upgrades."
+    },
+    {
+      "task_id": "update-notifications",
+      "status": "done",
+      "summary": "Surfaced toolkit version badges and update availability on the admin overview with catalog polling and error handling."
+    },
+    {
+      "task_id": "versioning-scheme",
+      "status": "in_progress",
+      "summary": "Persisted manifest versions across installs to unblock update flows; formal documentation of the scheme remains outstanding."
+    },
     {
       "task_id": "toolkit-runtime-docs",
       "status": "done",

--- a/backend/alembic/versions/20241025_0005_toolkit_version_column.py
+++ b/backend/alembic/versions/20241025_0005_toolkit_version_column.py
@@ -1,0 +1,24 @@
+"""Add version column to toolkits
+
+Revision ID: 20241025_0005
+Revises: 20241020_0004
+Create Date: 2024-10-25 00:05:00
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "20241025_0005"
+down_revision = "20241020_0004"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("toolkits", sa.Column("version", sa.String(length=64), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("toolkits", "version")

--- a/backend/app/models/toolkit.py
+++ b/backend/app/models/toolkit.py
@@ -19,6 +19,7 @@ class Toolkit(Base):
     enabled: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
     category: Mapped[str] = mapped_column(String(64), default="toolkit", nullable=False)
     tags: Mapped[List[str]] = mapped_column(JSON, default=list)
+    version: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
     origin: Mapped[str] = mapped_column(String(32), default="custom", nullable=False)
     backend_module: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     backend_router_attr: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)

--- a/backend/app/toolkits/install_utils.py
+++ b/backend/app/toolkits/install_utils.py
@@ -124,6 +124,11 @@ def install_toolkit_from_directory(
     if not base_path.startswith("/"):
         base_path = "/" + base_path.lstrip("/")
 
+    raw_version = manifest.get("version")
+    version = str(raw_version).strip() if raw_version is not None else None
+    if version == "":
+        version = None
+
     backend_manifest = manifest.get("backend", {})
     backend_module = backend_manifest.get("module")
     backend_router_attr = backend_manifest.get("router_attr")
@@ -206,6 +211,7 @@ def install_toolkit_from_directory(
         dashboard_context_attr=dashboard_context_attr,
         frontend_entry=frontend_entry,
         frontend_source_entry=frontend_source_entry,
+        version=version,
     )
 
     existing = get_toolkit(slug)
@@ -224,6 +230,7 @@ def install_toolkit_from_directory(
         update_payload.dashboard_context_attr = dashboard_context_attr
         update_payload.frontend_entry = frontend_entry
         update_payload.frontend_source_entry = frontend_source_entry
+        update_payload.version = version
         if not preserve_enabled:
             update_payload.enabled = payload.enabled
 

--- a/backend/app/toolkits/registry.py
+++ b/backend/app/toolkits/registry.py
@@ -33,6 +33,7 @@ class ToolkitRecord(BaseModel):
     category: str = Field(default="toolkit", description="Grouping hint for UI")
     tags: List[str] = Field(default_factory=list)
     origin: str = Field(default="builtin", description="Source of toolkit definition")
+    version: str | None = Field(default=None, description="Toolkit version reported by toolkit.json")
     backend_module: str | None = Field(default=None, description="Import path for plugin FastAPI module")
     backend_router_attr: str | None = Field(default=None, description="Attribute on backend module exposing an APIRouter")
     worker_module: str | None = Field(default=None, description="Import path for plugin Celery tasks")
@@ -59,6 +60,7 @@ class ToolkitCreate(BaseModel):
     enabled: bool = True
     category: str = "toolkit"
     tags: List[str] = Field(default_factory=list)
+    version: Optional[str] = None
     backend_module: Optional[str] = None
     backend_router_attr: Optional[str] = None
     worker_module: Optional[str] = None
@@ -82,6 +84,7 @@ class ToolkitUpdate(BaseModel):
     enabled: Optional[bool] = None
     category: Optional[str] = None
     tags: Optional[List[str]] = None
+    version: Optional[str] = None
     backend_module: Optional[str] = None
     backend_router_attr: Optional[str] = None
     worker_module: Optional[str] = None
@@ -127,6 +130,7 @@ def _record_from_model(model: Toolkit) -> ToolkitRecord:
         category=model.category,
         tags=list(model.tags or []),
         origin=model.origin,
+        version=model.version,
         backend_module=model.backend_module,
         backend_router_attr=model.backend_router_attr,
         worker_module=model.worker_module,
@@ -183,6 +187,7 @@ def _apply_record(model: Toolkit, record: ToolkitRecord) -> bool:
         "category": record.category,
         "tags": list(record.tags or []),
         "origin": record.origin,
+        "version": record.version,
         "backend_module": record.backend_module,
         "backend_router_attr": record.backend_router_attr,
         "worker_module": record.worker_module,
@@ -278,6 +283,7 @@ def create_toolkit(payload: ToolkitCreate, origin: str = "custom") -> ToolkitRec
             category=payload.category,
             tags=list(payload.tags or []),
             origin=origin,
+            version=payload.version,
             backend_module=payload.backend_module,
             backend_router_attr=payload.backend_router_attr,
             worker_module=payload.worker_module,

--- a/backend/tests/test_toolkits_catalog.py
+++ b/backend/tests/test_toolkits_catalog.py
@@ -123,7 +123,7 @@ async def test_toolkits_install_from_catalog_downloads_bundle(tmp_path, monkeypa
     dummy_client = DummyAsyncClient([download_response])
     monkeypatch.setattr(toolkits.httpx, "AsyncClient", lambda *a, **kw: dummy_client)
 
-    record = SimpleNamespace(slug="demo", name="Demo Toolkit", origin="community", enabled=False)
+    record = SimpleNamespace(slug="demo", name="Demo Toolkit", origin="community", enabled=False, version=None)
     monkeypatch.setattr(toolkits, "install_toolkit_from_directory", MagicMock(return_value=record))
     monkeypatch.setattr(toolkits, "UserService", lambda session: UserServiceStub(session))
 
@@ -181,7 +181,7 @@ async def test_toolkits_install_from_catalog_uses_catalog_base_for_relative_bund
     dummy_client = DummyAsyncClient([success_response])
     monkeypatch.setattr(toolkits.httpx, "AsyncClient", lambda *a, **kw: dummy_client)
 
-    record = SimpleNamespace(slug="demo", name="Demo Toolkit", origin="community", enabled=False)
+    record = SimpleNamespace(slug="demo", name="Demo Toolkit", origin="community", enabled=False, version=None)
     monkeypatch.setattr(toolkits, "install_toolkit_from_directory", MagicMock(return_value=record))
     monkeypatch.setattr(toolkits, "UserService", lambda session: UserServiceStub(session))
 
@@ -254,7 +254,7 @@ async def test_toolkits_install_from_catalog_falls_back_to_manifest_when_catalog
     dummy_client = DummyAsyncClient([first_response, second_response, final_response])
     monkeypatch.setattr(toolkits.httpx, "AsyncClient", lambda *a, **kw: dummy_client)
 
-    record = SimpleNamespace(slug="demo", name="Demo Toolkit", origin="community", enabled=False)
+    record = SimpleNamespace(slug="demo", name="Demo Toolkit", origin="community", enabled=False, version=None)
     monkeypatch.setattr(toolkits, "install_toolkit_from_directory", MagicMock(return_value=record))
     monkeypatch.setattr(toolkits, "UserService", lambda session: UserServiceStub(session))
 

--- a/backend/tests/test_toolkits_install.py
+++ b/backend/tests/test_toolkits_install.py
@@ -64,7 +64,7 @@ async def test_toolkits_install_strips_directory_segments(tmp_path, monkeypatch)
     storage_dir.mkdir(parents=True, exist_ok=True)
     monkeypatch.setattr(toolkits.settings, "toolkit_storage_dir", storage_dir)
 
-    record = SimpleNamespace(slug="clean", name="Clean Toolkit", origin="uploaded", enabled=False)
+    record = SimpleNamespace(slug="clean", name="Clean Toolkit", origin="uploaded", enabled=False, version=None)
     monkeypatch.setattr(toolkits, "install_toolkit_from_directory", MagicMock(return_value=record))
 
     bundle = io.BytesIO()
@@ -105,7 +105,9 @@ async def test_toolkits_install_randomises_collisions(tmp_path, monkeypatch):
     existing = storage_dir / "duplicate.zip"
     existing.write_bytes(b"existing")
 
-    record = SimpleNamespace(slug="frombundle", name="Bundled Toolkit", origin="uploaded", enabled=False)
+    record = SimpleNamespace(
+        slug="frombundle", name="Bundled Toolkit", origin="uploaded", enabled=False, version=None
+    )
     monkeypatch.setattr(toolkits, "install_toolkit_from_directory", MagicMock(return_value=record))
 
     bundle = io.BytesIO()

--- a/backend/tests/test_toolkits_seeder.py
+++ b/backend/tests/test_toolkits_seeder.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+import pytest
+
+from app.toolkits import seeder
+
+
+def test_discover_bundled_toolkits_uses_manifest_slug(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo_root = tmp_path / "repo"
+    module_path = repo_root / "backend" / "app" / "toolkits" / "seeder.py"
+    module_path.parent.mkdir(parents=True, exist_ok=True)
+    module_path.write_text("# stub module path for testing\n")
+
+    bundled_dir = repo_root / "toolkits" / "bundled" / "toolbox_health"
+    bundled_dir.mkdir(parents=True, exist_ok=True)
+    (bundled_dir / "toolkit.json").write_text('{"slug": "toolbox-health"}')
+
+    monkeypatch.setattr(seeder, "__file__", str(module_path))
+
+    mapping = seeder._discover_bundled_toolkits()
+
+    assert "toolbox-health" in mapping
+    assert mapping["toolbox-health"].resolve() == bundled_dir.resolve()

--- a/backend/tests/test_toolkits_updates.py
+++ b/backend/tests/test_toolkits_updates.py
@@ -1,0 +1,156 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from pydantic import AnyHttpUrl
+
+from app.routes import toolkits
+from app.toolkits.registry import ToolkitRecord
+
+
+def make_session_stub():
+    return SimpleNamespace(
+        add=AsyncMock(),
+        flush=AsyncMock(),
+        commit=AsyncMock(),
+        delete=AsyncMock(),
+        get=AsyncMock(return_value=None),
+    )
+
+
+@pytest.mark.anyio("asyncio")
+async def test_toolkits_updates_reports_catalog_version(monkeypatch):
+    record = ToolkitRecord(
+        slug="demo",
+        name="Demo",
+        description="",
+        base_path="/toolkits/demo",
+        enabled=True,
+        category="toolkit",
+        tags=[],
+        origin="community",
+        version="1.0.0",
+        backend_module=None,
+        backend_router_attr=None,
+        worker_module=None,
+        worker_register_attr=None,
+        dashboard_cards=[],
+        dashboard_context_module=None,
+        dashboard_context_attr=None,
+        frontend_entry=None,
+        frontend_source_entry=None,
+    )
+
+    monkeypatch.setattr(toolkits, "list_toolkits", lambda: [record])
+    monkeypatch.setattr(
+        toolkits,
+        "_resolve_catalog_url",
+        AsyncMock(return_value=(AnyHttpUrl("https://catalog.example/toolkits.json"), None)),
+    )
+    monkeypatch.setattr(
+        toolkits,
+        "_fetch_community_catalog",
+        AsyncMock(
+            return_value=[
+                toolkits.CommunityToolkitEntry(
+                    slug="demo",
+                    name="Demo",
+                    version="1.1.0",
+                    bundle_url="demo.zip",
+                )
+            ]
+        ),
+    )
+
+    session = make_session_stub()
+    result = await toolkits.toolkits_updates(session=session)
+
+    assert len(result) == 1
+    status = result[0]
+    assert status.slug == "demo"
+    assert status.update_available is True
+    assert status.available_version == "1.1.0"
+    assert status.source == "https://catalog.example/toolkits.json"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_toolkits_update_bundle_invokes_catalog_install(monkeypatch):
+    record = ToolkitRecord(
+        slug="demo",
+        name="Demo",
+        description="",
+        base_path="/toolkits/demo",
+        enabled=True,
+        category="toolkit",
+        tags=[],
+        origin="community",
+        version="1.0.0",
+        backend_module=None,
+        backend_router_attr=None,
+        worker_module=None,
+        worker_register_attr=None,
+        dashboard_cards=[],
+        dashboard_context_module=None,
+        dashboard_context_attr=None,
+        frontend_entry=None,
+        frontend_source_entry=None,
+    )
+
+    updated = record.model_copy(update={"version": "1.1.0"})
+
+    monkeypatch.setattr(toolkits, "get_toolkit", lambda slug: record)
+    monkeypatch.setattr(toolkits, "_get_toolkit_or_404", lambda slug: record)
+    install_mock = AsyncMock(return_value=updated)
+    monkeypatch.setattr(toolkits, "toolkits_install_from_catalog", install_mock)
+
+    session = make_session_stub()
+    request = SimpleNamespace(client=SimpleNamespace(host="127.0.0.1"), headers={})
+
+    result = await toolkits.toolkits_update_bundle(
+        slug="demo",
+        request=request,
+        session=session,
+        current_user=SimpleNamespace(),
+    )
+
+    install_mock.assert_awaited_once()
+    assert result.version == "1.1.0"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_toolkits_update_bundle_rejects_non_community(monkeypatch):
+    record = ToolkitRecord(
+        slug="demo",
+        name="Demo",
+        description="",
+        base_path="/toolkits/demo",
+        enabled=True,
+        category="toolkit",
+        tags=[],
+        origin="uploaded",
+        version="1.0.0",
+        backend_module=None,
+        backend_router_attr=None,
+        worker_module=None,
+        worker_register_attr=None,
+        dashboard_cards=[],
+        dashboard_context_module=None,
+        dashboard_context_attr=None,
+        frontend_entry=None,
+        frontend_source_entry=None,
+    )
+
+    monkeypatch.setattr(toolkits, "_get_toolkit_or_404", lambda slug: record)
+
+    request = SimpleNamespace(client=SimpleNamespace(host="127.0.0.1"), headers={})
+
+    with pytest.raises(toolkits.HTTPException) as exc_info:
+        await toolkits.toolkits_update_bundle(
+            slug="demo",
+            request=request,
+            session=make_session_stub(),
+            current_user=SimpleNamespace(),
+        )
+
+    assert exc_info.value.status_code == toolkits.status.HTTP_400_BAD_REQUEST
+    assert "only supported" in exc_info.value.detail

--- a/docs/TODO.yaml
+++ b/docs/TODO.yaml
@@ -120,27 +120,27 @@ areas:
     tasks:
       - id: versioning-scheme
         title: Define a versioning scheme for toolkits (e.g., semantic versioning).
-        status: backlog
-        priority: medium
+        status: in_progress
+        priority: high
         notes:
           - "Establish guidelines for version increments based on changes (major, minor, patch)."
           - "Document the versioning scheme in the toolkit repository."
+          - "2024-10-25: Toolkits now persist manifest-provided versions and surface them in the UI; formal documentation of the scheme remains outstanding."
         blockers:
           - "Requires toolkit repository setup."
       - id: update-notifications
         title: Implement a notification system within the Toolbox UI to alert users of available toolkit updates.
-        status: backlog
-        priority: medium
+        status: done
+        priority: high
         notes:
           - "Consider in-app notifications or a dedicated updates section."
           - "Provide details about the update, including changelog and impact."
           - "Allow users to easily initiate updates from the notification."
-        blockers:
-          - "Requires completion of the versioning scheme task."
+          - "2024-10-25: Admin → Toolkits overview now displays version badges, update availability, and catalog hints with automated polling."
       - id: update-mechanism
         title: Develop a mechanism to safely update installed toolkits.
-        status: backlog
-        priority: medium
+        status: done
+        priority: high
         notes:
           - "Ensure updates can be rolled back in case of issues."
           - "Consider version compatibility checks before applying updates."
@@ -148,12 +148,11 @@ areas:
           - "Allow upload of updated toolkit zips via the UI or API."
           - "Should validate the zip contents and version before applying."
           - "Should also support updates from the community repository."
-        blockers:
-          - "Requires completion of the versioning scheme and update notifications tasks."
+          - "2024-10-25: Added /toolkits/{slug}/update endpoint reusing catalog installs with manifest version validation and audit logging; UI exposes one-click updates for community toolkits."
       - id: backport-toolkit-update-mechanism
         title: Backport the update mechanism to existing installations.
         status: backlog
-        priority: low
+        priority: medium
         notes:
           - "Assess the feasibility of integrating the update mechanism into current versions of the toolkits."
           - "Plan for a phased rollout to minimize disruption for existing users."

--- a/frontend/src/ToolkitContext.tsx
+++ b/frontend/src/ToolkitContext.tsx
@@ -10,6 +10,7 @@ export type ToolkitRecord = ToolkitSummary & {
   category: string
   tags: string[]
   origin: string
+  version?: string | null
   created_at: string
   updated_at: string
   backend_module?: string | null

--- a/frontend/src/pages/AdminToolkitsPage.css
+++ b/frontend/src/pages/AdminToolkitsPage.css
@@ -155,6 +155,12 @@
   color: var(--color-text-muted);
 }
 
+.admin-toolkits__item-hint {
+  margin-top: 0.35rem;
+  font-size: 0.75rem;
+  color: var(--color-warning-text);
+}
+
 .admin-toolkits__item-actions {
   display: inline-flex;
   align-items: center;
@@ -194,6 +200,20 @@
 .admin-toolkits__icon-button.is-error {
   background: var(--color-danger-bg);
   border-radius: 10px;
+}
+
+.admin-toolkits__update-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0 0.45rem;
+  border-radius: 999px;
+  background: var(--color-warning-bg, rgba(255, 193, 7, 0.15));
+  color: var(--color-warning-text);
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
 }
 
 .admin-toolkits__form {
@@ -421,6 +441,12 @@
   margin: 0;
   color: var(--color-success-text);
   font-size: 0.85rem;
+}
+
+.admin-toolkits__updates-loading {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  font-style: italic;
 }
 
 .admin-toolkits__error {


### PR DESCRIPTION
## Summary
- persist toolkit manifest versions in the registry, add a migration, and correct bundled toolkit slug discovery
- expose `/toolkits/updates` plus `/toolkits/{slug}/update` for community bundle refresh with regression tests
- surface version/update indicators and actions in the admin overview UI with matching Vitest coverage

## Testing
- pytest backend/tests/test_toolkits_install_utils.py backend/tests/test_toolkits_catalog.py backend/tests/test_toolkits_install.py backend/tests/test_toolkits_updates.py backend/tests/test_toolkits_seeder.py
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_b_68d37f5eec2483288f6496b09f7a4ba6