### PR TITLE
Add Kubernetes manifests for toolbox deployment

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,0 +1,47 @@
+# Kubernetes Manifests
+
+These manifests provide a baseline deployment of the toolbox stack on Kubernetes. They mirror the services defined in `docker-compose.yml` and assume container images have been built and published to a registry that your cluster can pull from.
+
+## Contents
+
+- `namespace.yaml` – creates the `sre-toolbox` namespace used by the other resources.
+- `configmap.yaml` – non-sensitive shared configuration values consumed by the API and worker.
+- `secrets.yaml` – placeholder secrets for database credentials, application secrets, and Vault tokens/keys.
+- `config-files.yaml` – configuration files (such as `auth-providers.json` and Vault HCL/entrypoint) packaged as ConfigMaps.
+- `persistentvolumeclaims.yaml` – persistent volumes for shared application data.
+- `postgres.yaml` – StatefulSet and Service for PostgreSQL.
+- `redis.yaml` – Deployment and Service for Redis.
+- `vault.yaml` – StatefulSet and Service for HashiCorp Vault.
+- `api.yaml` – Deployment and Service for the FastAPI backend.
+- `worker.yaml` – Deployment for the Celery worker process.
+- `frontend.yaml` – Deployment and Service for the Vite development server that serves the UI.
+
+## Usage
+
+1. Build and push the backend and frontend images referenced in the manifests to a registry accessible by the cluster. Update the `image` fields in `api.yaml`, `worker.yaml`, and `frontend.yaml` to match your registry paths.
+2. Review `secrets.yaml` and replace the placeholder values with credentials appropriate for your environment. For sensitive values, consider using your platform's secret management tool instead of committing them to source control.
+3. (Optional) Update `configmap.yaml` to match your Vault deployment requirements or other runtime settings.
+4. Apply the manifests in order, starting with the namespace and configuration:
+
+   ```bash
+   kubectl apply -f kubernetes/namespace.yaml
+   kubectl apply -f kubernetes/configmap.yaml
+   kubectl apply -f kubernetes/secrets.yaml
+   kubectl apply -f kubernetes/config-files.yaml
+   kubectl apply -f kubernetes/persistentvolumeclaims.yaml
+   kubectl apply -f kubernetes/postgres.yaml
+   kubectl apply -f kubernetes/redis.yaml
+   kubectl apply -f kubernetes/vault.yaml
+   kubectl apply -f kubernetes/api.yaml
+   kubectl apply -f kubernetes/worker.yaml
+   kubectl apply -f kubernetes/frontend.yaml
+   ```
+
+5. Configure ingress or port-forwarding as needed to expose the frontend and API outside the cluster.
+
+## Notes
+
+- The shared `toolbox-shared-data` PersistentVolumeClaim requires a storage class that supports the `ReadWriteMany` access mode. Adjust the manifests to match your cluster's storage offerings if necessary.
+- The Vault StatefulSet references an init script and configuration packaged in `config-files.yaml`. You must still initialize and unseal Vault (or configure auto-unseal) before the rest of the stack can use it.
+- The provided `auth-providers.json` configuration is the example bundled with the repository. Update it to match your identity providers before using the stack in production.
+- For production workloads you may want to replace the frontend Deployment with a static asset build served by a more production-ready web server.

--- a/kubernetes/api.yaml
+++ b/kubernetes/api.yaml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: toolbox-api
+  namespace: sre-toolbox
+spec:
+  selector:
+    app: toolbox-api
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: toolbox-api
+  namespace: sre-toolbox
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: toolbox-api
+  template:
+    metadata:
+      labels:
+        app: toolbox-api
+    spec:
+      containers:
+        - name: api
+          image: ghcr.io/your-org/sre-toolbox-api:latest
+          imagePullPolicy: IfNotPresent
+          command: ["sh", "-c", "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8080"]
+          ports:
+            - containerPort: 8080
+              name: http
+          envFrom:
+            - configMapRef:
+                name: toolbox-app-config
+            - secretRef:
+                name: toolbox-app-secrets
+            - secretRef:
+                name: toolbox-postgres-credentials
+          volumeMounts:
+            - name: shared-data
+              mountPath: /app/data
+            - name: backend-config
+              mountPath: /app/config
+              readOnly: true
+            - name: vault-token
+              mountPath: /app/.vault-token
+              subPath: .vault-token
+              readOnly: true
+      volumes:
+        - name: shared-data
+          persistentVolumeClaim:
+            claimName: toolbox-shared-data
+        - name: backend-config
+          configMap:
+            name: toolbox-backend-config
+        - name: vault-token
+          secret:
+            secretName: toolbox-vault-token

--- a/kubernetes/config-files.yaml
+++ b/kubernetes/config-files.yaml
@@ -1,0 +1,206 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: toolbox-backend-config
+  namespace: sre-toolbox
+data:
+  auth-providers.json: |-
+    [
+      {
+        "name": "local",
+        "type": "local",
+        "display_name": "Local Accounts",
+        "enabled": true,
+        "allow_registration": false,
+        "default_roles": ["toolkit.user"]
+      },
+      {
+        "name": "okta",
+        "type": "oidc",
+        "display_name": "Okta",
+        "enabled": false,
+        "discovery_url": "https://YOUR_OKTA_DOMAIN/.well-known/openid-configuration",
+        "client_id": "OKTA_CLIENT_ID",
+        "client_secret_vault": {
+          "mount": "sre",
+          "path": "auth/okta",
+          "key": "client_secret",
+          "engine": "kv-v2"
+        },
+        "redirect_base_url": "http://localhost:5173",
+        "scopes": ["openid", "profile", "email"],
+        "group_claim": "groups",
+        "role_mappings": {
+          "sre-admins": ["system.admin"],
+          "sre-curators": ["toolkit.curator"]
+        }
+      },
+      {
+        "name": "azuread",
+        "type": "oidc",
+        "display_name": "Azure AD",
+        "enabled": false,
+        "discovery_url": "https://login.microsoftonline.com/YOUR_TENANT_ID/v2.0/.well-known/openid-configuration",
+        "client_id": "AZURE_CLIENT_ID",
+        "client_secret_vault": {
+          "mount": "sre",
+          "path": "auth/azuread",
+          "key": "client_secret",
+          "engine": "kv-v2"
+        },
+        "redirect_base_url": "http://localhost:5173",
+        "scopes": ["openid", "profile", "email"],
+        "group_claim": "roles",
+        "role_mappings": {
+          "SRE-Operations": ["toolkit.curator"],
+          "SRE-Admins": ["system.admin"]
+        },
+        "use_pkce": true
+      },
+      {
+        "name": "corp-ldap",
+        "type": "ldap",
+        "display_name": "Corporate LDAP",
+        "enabled": false,
+        "server_uri": "ldaps://ldap.example.com",
+        "bind_dn": "cn=service,ou=system,dc=example,dc=com",
+        "bind_password_vault": {
+          "mount": "sre",
+          "path": "auth/ldap",
+          "key": "bind_password",
+          "engine": "kv-v2"
+        },
+        "user_search_base": "ou=people,dc=example,dc=com",
+        "user_filter": "(&(objectClass=person)(uid={username}))",
+        "group_search_base": "ou=groups,dc=example,dc=com",
+        "group_filter": "(&(objectClass=groupOfNames)(member={user_dn}))",
+        "role_mappings": {
+          "cn=sre-admins,ou=groups,dc=example,dc=com": ["system.admin"],
+          "cn=sre-operators,ou=groups,dc=example,dc=com": ["toolkit.curator"]
+        }
+      },
+      {
+        "name": "corp-ad",
+        "type": "active_directory",
+        "display_name": "Active Directory",
+        "enabled": false,
+        "server_uri": "ldaps://dc1.example.corp",
+        "default_domain": "example.corp",
+        "bind_dn": "CN=ServiceAccount,OU=Service,DC=example,DC=corp",
+        "bind_password_vault": {
+          "mount": "sre",
+          "path": "auth/ad",
+          "key": "bind_password",
+          "engine": "kv-v2"
+        },
+        "user_search_base": "OU=Users,DC=example,DC=corp",
+        "user_filter": "(&(objectClass=user)(sAMAccountName={username}))",
+        "group_search_base": "OU=Groups,DC=example,DC=corp",
+        "group_filter": "(&(objectClass=group)(member={user_dn}))",
+        "role_mappings": {
+          "CN=ToolboxAdmins,OU=Groups,DC=example,DC=corp": ["system.admin"],
+          "CN=ToolboxOperators,OU=Groups,DC=example,DC=corp": ["toolkit.curator"]
+        }
+      }
+    ]
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: toolbox-vault-config
+  namespace: sre-toolbox
+data:
+  local.hcl: |-
+    ui = true
+    api_addr = "http://toolbox-vault:8200"
+    cluster_addr = "http://toolbox-vault:8201"
+
+    storage "file" {
+      path = "/vault/data"
+    }
+
+    listener "tcp" {
+      address = "0.0.0.0:8200"
+      cluster_address = "0.0.0.0:8201"
+      tls_disable = 1
+    }
+
+    default_lease_ttl = "168h"
+    max_lease_ttl = "720h"
+  entrypoint.sh: |-
+    #!/bin/sh
+    set -eu
+
+    VAULT_SERVER_CONFIG_PATH=${VAULT_SERVER_CONFIG_PATH:-/vault/config/local.hcl}
+    VAULT_CONFIG_PATH=${VAULT_SERVER_CONFIG_PATH}
+    VAULT_ADDR_INTERNAL=${VAULT_ADDR_INTERNAL:-http://127.0.0.1:${VAULT_LISTEN_PORT:-8200}}
+    VAULT_BIN=${VAULT_BIN:-vault}
+    UNSEAL_KEY=${VAULT_UNSEAL_KEY:-}
+    UNSEAL_KEY_FILE=${VAULT_UNSEAL_KEY_FILE:-}
+
+    if [ ! -f "${VAULT_CONFIG_PATH}" ]; then
+      if [ -n "${VAULT_LOCAL_CONFIG:-}" ]; then
+        printf '%s\n' "${VAULT_LOCAL_CONFIG}" > /tmp/vault-local-config.json
+        VAULT_CONFIG_PATH=/tmp/vault-local-config.json
+      else
+        echo "[vault-entrypoint] No Vault configuration found at ${VAULT_CONFIG_PATH} and VAULT_LOCAL_CONFIG is empty." >&2
+        exit 1
+      fi
+    fi
+
+    ${VAULT_BIN} server -config="${VAULT_CONFIG_PATH}" &
+    VAULT_PID=$!
+
+    cleanup() {
+      kill "${VAULT_PID}" 2>/dev/null || true
+      wait "${VAULT_PID}" 2>/dev/null || true
+    }
+    trap cleanup INT TERM
+
+    export VAULT_ADDR="${VAULT_ADDR_INTERNAL}"
+
+    attempt=0
+    status_json=""
+    while true; do
+      status_json=$(${VAULT_BIN} status -format=json 2>/tmp/vault-status.err || true)
+      if echo "${status_json}" | grep -q '"initialized"'; then
+        break
+      fi
+      attempt=$((attempt + 1))
+      if [ "${attempt}" -ge 60 ]; then
+        echo "[vault-entrypoint] Vault failed to start within timeout" >&2
+        cat /tmp/vault-status.err >&2 || true
+        cleanup
+        exit 1
+      fi
+      sleep 1
+    done
+
+    initialized=$(echo "${status_json}" | sed -n 's/.*"initialized"[[:space:]]*:[[:space:]]*\(true\|false\).*/\1/p' | head -n1)
+    sealed=$(echo "${status_json}" | sed -n 's/.*"sealed"[[:space:]]*:[[:space:]]*\(true\|false\).*/\1/p' | head -n1)
+    initialized=${initialized:-false}
+    sealed=${sealed:-true}
+
+    if [ "${initialized}" != "true" ]; then
+      echo "[vault-entrypoint] Vault is not initialised. Complete initialisation manually before relying on auto-unseal." >&2
+      wait "${VAULT_PID}"
+    fi
+
+    if [ "${sealed}" = "true" ]; then
+      key="${UNSEAL_KEY}"
+      if [ -z "${key}" ] && [ -n "${UNSEAL_KEY_FILE}" ] && [ -f "${UNSEAL_KEY_FILE}" ]; then
+        key=$(cat "${UNSEAL_KEY_FILE}")
+      fi
+      if [ -z "${key}" ] && [ -n "${UNSEAL_KEY_FILE}" ]; then
+        echo "[vault-entrypoint] Unseal key file not found: ${UNSEAL_KEY_FILE}" >&2
+      fi
+      key=$(printf '%s' "${key}" | tr -d '\r\n')
+      if [ -z "${key}" ]; then
+        echo "[vault-entrypoint] Vault is sealed and no unseal key provided (set VAULT_UNSEAL_KEY or VAULT_UNSEAL_KEY_FILE)." >&2
+        wait "${VAULT_PID}"
+      fi
+      echo "[vault-entrypoint] Auto-unsealing Vault (source=${UNSEAL_KEY:+env}${UNSEAL_KEY:+,}${UNSEAL_KEY_FILE:+file:${UNSEAL_KEY_FILE}})..."
+      ${VAULT_BIN} operator unseal "${key}"
+    fi
+
+    wait "${VAULT_PID}"

--- a/kubernetes/configmap.yaml
+++ b/kubernetes/configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: toolbox-app-config
+  namespace: sre-toolbox
+data:
+  PYTHONPATH: /app
+  VAULT_ADDR: http://toolbox-vault:8200
+  VAULT_NAMESPACE: ""
+  VAULT_KV_MOUNT: secret
+  VAULT_TLS_SKIP_VERIFY: "true"
+  VAULT_CA_CERT: ""
+  VAULT_AUTH_METHOD: token
+  VAULT_TOKEN_FILE: /vault/.vault-token
+  CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP: "true"

--- a/kubernetes/configmap.yaml
+++ b/kubernetes/configmap.yaml
@@ -11,5 +11,6 @@ data:
   VAULT_TLS_SKIP_VERIFY: "true"
   VAULT_CA_CERT: ""
   VAULT_AUTH_METHOD: token
-  VAULT_TOKEN_FILE: /vault/.vault-token
+  VAULT_TOKEN_FILE: /app/.vault-token
+  REDIS_URL: redis://toolbox-redis:6379/0
   CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP: "true"

--- a/kubernetes/frontend.yaml
+++ b/kubernetes/frontend.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: toolbox-frontend
+  namespace: sre-toolbox
+spec:
+  selector:
+    app: toolbox-frontend
+  ports:
+    - name: http
+      port: 5173
+      targetPort: 5173
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: toolbox-frontend
+  namespace: sre-toolbox
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: toolbox-frontend
+  template:
+    metadata:
+      labels:
+        app: toolbox-frontend
+    spec:
+      containers:
+        - name: frontend
+          image: ghcr.io/your-org/sre-toolbox-frontend:latest
+          imagePullPolicy: IfNotPresent
+          command: ["sh", "-c", "npm run dev -- --host 0.0.0.0 --port 5173"]
+          ports:
+            - containerPort: 5173
+              name: http
+          env:
+            - name: VITE_API_BASE_URL
+              value: http://toolbox-api:8080

--- a/kubernetes/namespace.yaml
+++ b/kubernetes/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sre-toolbox

--- a/kubernetes/persistentvolumeclaims.yaml
+++ b/kubernetes/persistentvolumeclaims.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: toolbox-shared-data
+  namespace: sre-toolbox
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 5Gi

--- a/kubernetes/postgres.yaml
+++ b/kubernetes/postgres.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: toolbox-postgres
+  namespace: sre-toolbox
+spec:
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+  selector:
+    app: toolbox-postgres
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: toolbox-postgres
+  namespace: sre-toolbox
+spec:
+  serviceName: toolbox-postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app: toolbox-postgres
+  template:
+    metadata:
+      labels:
+        app: toolbox-postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:15-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 5432
+              name: postgres
+          envFrom:
+            - secretRef:
+                name: toolbox-postgres-credentials
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 20Gi

--- a/kubernetes/redis.yaml
+++ b/kubernetes/redis.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: toolbox-redis
+  namespace: sre-toolbox
+spec:
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: 6379
+  selector:
+    app: toolbox-redis
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: toolbox-redis
+  namespace: sre-toolbox
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: toolbox-redis
+  template:
+    metadata:
+      labels:
+        app: toolbox-redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 6379
+              name: redis

--- a/kubernetes/secrets.yaml
+++ b/kubernetes/secrets.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: toolbox-postgres-credentials
+  namespace: sre-toolbox
+type: Opaque
+stringData:
+  POSTGRES_DB: toolbox
+  POSTGRES_USER: toolbox
+  POSTGRES_PASSWORD: change-me
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: toolbox-app-secrets
+  namespace: sre-toolbox
+type: Opaque
+stringData:
+  DATABASE_URL: postgresql://toolbox:change-me@toolbox-postgres:5432/toolbox
+  VAULT_TOKEN: ""
+  VAULT_APPROLE_ROLE_ID: ""
+  VAULT_APPROLE_SECRET_ID: ""
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: toolbox-vault-token
+  namespace: sre-toolbox
+type: Opaque
+stringData:
+  .vault-token: ""
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: toolbox-vault-unseal
+  namespace: sre-toolbox
+type: Opaque
+stringData:
+  unseal-key: ""

--- a/kubernetes/vault.yaml
+++ b/kubernetes/vault.yaml
@@ -1,0 +1,97 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: toolbox-vault
+  namespace: sre-toolbox
+spec:
+  ports:
+    - name: http
+      port: 8200
+      targetPort: 8200
+  selector:
+    app: toolbox-vault
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: toolbox-vault
+  namespace: sre-toolbox
+spec:
+  serviceName: toolbox-vault
+  replicas: 1
+  selector:
+    matchLabels:
+      app: toolbox-vault
+  template:
+    metadata:
+      labels:
+        app: toolbox-vault
+    spec:
+      containers:
+        - name: vault
+          image: hashicorp/vault:1.14
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "/vault/init-unseal.sh"]
+          env:
+            - name: VAULT_SERVER_CONFIG_PATH
+              value: /vault/config/local.hcl
+            - name: VAULT_LISTEN_PORT
+              value: "8200"
+            - name: VAULT_ADDR
+              valueFrom:
+                configMapKeyRef:
+                  name: toolbox-app-config
+                  key: VAULT_ADDR
+            - name: VAULT_TLS_SKIP_VERIFY
+              valueFrom:
+                configMapKeyRef:
+                  name: toolbox-app-config
+                  key: VAULT_TLS_SKIP_VERIFY
+            - name: VAULT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: toolbox-app-secrets
+                  key: VAULT_TOKEN
+            - name: VAULT_UNSEAL_KEY_FILE
+              value: /vault/secrets/unseal-key
+          ports:
+            - containerPort: 8200
+              name: http
+          volumeMounts:
+            - name: config
+              mountPath: /vault/config
+            - name: entrypoint
+              mountPath: /vault/init-unseal.sh
+              subPath: entrypoint.sh
+              readOnly: true
+            - name: unseal
+              mountPath: /vault/secrets
+              readOnly: true
+            - name: data
+              mountPath: /vault/data
+      volumes:
+        - name: config
+          configMap:
+            name: toolbox-vault-config
+            items:
+              - key: local.hcl
+                path: local.hcl
+        - name: entrypoint
+          configMap:
+            name: toolbox-vault-config
+            defaultMode: 0755
+            items:
+              - key: entrypoint.sh
+                path: entrypoint.sh
+        - name: unseal
+          secret:
+            secretName: toolbox-vault-unseal
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 5Gi

--- a/kubernetes/worker.yaml
+++ b/kubernetes/worker.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: toolbox-worker
+  namespace: sre-toolbox
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: toolbox-worker
+  template:
+    metadata:
+      labels:
+        app: toolbox-worker
+    spec:
+      containers:
+        - name: worker
+          image: ghcr.io/your-org/sre-toolbox-api:latest
+          imagePullPolicy: IfNotPresent
+          command: ["sh", "-c", "celery -A worker.worker:celery_app worker --loglevel=INFO"]
+          envFrom:
+            - configMapRef:
+                name: toolbox-app-config
+            - secretRef:
+                name: toolbox-app-secrets
+            - secretRef:
+                name: toolbox-postgres-credentials
+          volumeMounts:
+            - name: shared-data
+              mountPath: /app/data
+            - name: backend-config
+              mountPath: /app/config
+              readOnly: true
+            - name: vault-token
+              mountPath: /app/.vault-token
+              subPath: .vault-token
+              readOnly: true
+      volumes:
+        - name: shared-data
+          persistentVolumeClaim:
+            claimName: toolbox-shared-data
+        - name: backend-config
+          configMap:
+            name: toolbox-backend-config
+        - name: vault-token
+          secret:
+            secretName: toolbox-vault-token


### PR DESCRIPTION
## Summary
- add a kubernetes manifest suite for the api, worker, frontend, postgres, redis, and vault services
- provide supporting configmaps, secrets, persistent volume claims, and namespace resources
- document deployment steps and customization guidance in `kubernetes/README.md`

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_b_68d8582d289c8328b1df7243490495f5