### PR TITLE
Document toolkit versioning guidance

### DIFF
--- a/ai/state/journal.md
+++ b/ai/state/journal.md
@@ -94,3 +94,8 @@ Track Codex sessions chronologically. Each entry should capture what was attempt
 - Persisted manifest versions on install/update so registry + UI can surface semantic versions without touching bundled manifests.
 - Added `/toolkits/updates` API with packaging-based comparison, community catalog polling, and frontend badges for curators.
 - Introduced `/toolkits/{slug}/update` to reuse community installs for upgrades, wired admin UI actions, and refreshed TODO priorities.
+
+## 2025-09-25 Toolkit versioning documentation
+- Closed TODO `versioning-scheme` by writing `docs/toolkit-authoring/versioning.md`, defining semantic versioning expectations and release triggers for toolkit authors (Context: docs/TODO.yaml, toolkit authoring docs).
+- Linked the new guide from the authoring overview and testing & release checklist so curators see version bump rules during planning and packaging (Context: docs/toolkit-authoring/overview.md, docs/toolkit-authoring/testing-and-release.md).
+- Updated state tracking to mark the task complete and capture the documentation improvement (Context: ai/state/progress.json).

--- a/ai/state/progress.json
+++ b/ai/state/progress.json
@@ -1,9 +1,9 @@
 {
   "version": 1,
-  "last_updated": "2025-09-25T00:00:00+00:00",
-  "session_counter": 16,
+  "last_updated": "2025-09-25T00:15:00+00:00",
+  "session_counter": 17,
   "active_task": null,
-  "last_task_id": "update-mechanism",
+  "last_task_id": "versioning-scheme",
   "recent_updates": [
     {
       "task_id": "update-mechanism",
@@ -17,8 +17,8 @@
     },
     {
       "task_id": "versioning-scheme",
-      "status": "in_progress",
-      "summary": "Persisted manifest versions across installs to unblock update flows; formal documentation of the scheme remains outstanding."
+      "status": "done",
+      "summary": "Documented semantic versioning guidance, release checklist integration, and changelog expectations for toolkit authors."
     },
     {
       "task_id": "toolkit-runtime-docs",

--- a/docs/TODO.yaml
+++ b/docs/TODO.yaml
@@ -120,14 +120,13 @@ areas:
     tasks:
       - id: versioning-scheme
         title: Define a versioning scheme for toolkits (e.g., semantic versioning).
-        status: in_progress
+        status: done
         priority: high
         notes:
           - "Establish guidelines for version increments based on changes (major, minor, patch)."
           - "Document the versioning scheme in the toolkit repository."
           - "2024-10-25: Toolkits now persist manifest-provided versions and surface them in the UI; formal documentation of the scheme remains outstanding."
-        blockers:
-          - "Requires toolkit repository setup."
+          - "2025-09-25: Authored toolkit versioning guide and linked it through authoring docs and release checklist."
       - id: update-notifications
         title: Implement a notification system within the Toolbox UI to alert users of available toolkit updates.
         status: done

--- a/docs/toolkit-authoring/overview.md
+++ b/docs/toolkit-authoring/overview.md
@@ -34,4 +34,4 @@ Use this guide as the starting point for building SRE Toolbox toolkits. It conne
 
 The community repository ingests each toolkit's `docs/README.md` to generate catalog cards and quickstart links, so keeping that summary current ensures operators see accurate guidance wherever the toolkit is surfaced.
 
-Continue with the more detailed backend, frontend, and distribution guides in this folder.
+Continue with the more detailed backend, frontend, versioning, and distribution guides in this folder. Consult [`versioning.md`](./versioning.md) when planning releases so manifest versions, changelog entries, and `toolkit.updated_at` timestamps stay aligned.

--- a/docs/toolkit-authoring/testing-and-release.md
+++ b/docs/toolkit-authoring/testing-and-release.md
@@ -17,7 +17,7 @@ Follow this sequence before publishing a toolkit bundle so operators receive a r
 ## Packaging & Distribution
 - Build the frontend bundle (when applicable) so artifacts such as `frontend/dist/index.js` or custom `frontend.entry` targets exist before you commit.
 - Verify the slug in `toolkit.json` uses only lowercase letters, numbers, hyphen (`-`), or underscore (`_`); the release workflow fails quickly when the allowlist is violated.
-- Bump the toolkit version in `toolkit.json` and include a changelog entry summarising major changes and migration steps.
+- Bump the toolkit version in `toolkit.json` according to the [Toolkit Versioning Guide](./versioning.md) and include a changelog entry summarising major changes and migration steps.
 - Merge your branch (with built assets committed) into `main`. The **Release** GitHub Actions workflow runs on every push to `main`, invokes `toolkits/scripts/package_all_toolkits.py`, and uploads a `toolkit-<slug>` artifact containing `<slug>_toolkit.zip`.
 - Monitor the workflow under **Actions → Release**. You can download artifacts directly from the run summary or via `gh run download --repo <org>/<repo> --name toolkit-<slug>` once the `Package Toolkit` job succeeds.
 - Share the downloaded archive alongside release notes in your preferred artifact store, or hand it to the operations team for installation.

--- a/docs/toolkit-authoring/versioning.md
+++ b/docs/toolkit-authoring/versioning.md
@@ -1,0 +1,33 @@
+# Toolkit Versioning Guide
+
+Consistent version numbers help curators decide when to upgrade bundles and allow the Toolbox UI to surface accurate badges. Toolkits MUST follow semantic versioning (`MAJOR.MINOR.PATCH`) in their `toolkit.json` manifest and any release notes.
+
+## Version components
+- **MAJOR**: Increment when you introduce breaking changes that require operator action (database migrations that cannot be rolled back automatically, incompatible API responses, removed routes, renamed environment variables).
+- **MINOR**: Increment when you add new, backward-compatible capability (new UI tabs, optional API endpoints, additional job handlers) without forcing configuration changes.
+- **PATCH**: Increment for bug fixes, dependency upgrades that do not change behaviour, documentation-only corrections, or internal refactors that keep public contracts stable.
+
+Pre-release identifiers (e.g. `1.2.0-beta.1`) and build metadata (`+build.5`) are optional but MUST follow [Semantic Versioning 2.0.0](https://semver.org/) formatting. Avoid reusing version numbers—once a version is published, it is immutable.
+
+## When to bump versions
+Use the following checklist when deciding which component to bump:
+- Are operators required to run data migrations, rotate credentials, or change automation scripts? → **MAJOR**.
+- Did you add new functionality while keeping existing APIs, events, and UI intact? → **MINOR**.
+- Is the release fixing defects, polishing copy, or tightening observability without altering contracts? → **PATCH**.
+
+Bundle packaging captures `toolkit.json` verbatim, so the manifest version must be updated before the release workflow runs. Update the version **before** you merge so CI artifacts (`toolkit-<slug>/<slug>_toolkit.zip`) match the published release notes.
+
+## Changelog expectations
+Every release SHOULD include a changelog entry describing:
+- Summary of operator-facing changes.
+- Required follow-up tasks (migrations, new environment variables, feature flags).
+- Known compatibility or downgrade caveats.
+
+Store the changelog alongside your toolkit source (for example, `docs/CHANGELOG.md`) so the community repository and catalog cards can reference it. Link the entry in your release notes or documentation PR.
+
+## Release workflow integration
+- The Admin → Toolkits UI and API surfaces the manifest version. Ensure `toolkit.updated_at` is bumped when you release so the UI invalidates cached bundles.
+- Keep previous bundle artifacts accessible; they are required for rollbacks when a major release introduces regressions.
+- Coordinate version bumps with the [Testing & Release Checklist](./testing-and-release.md) to confirm automated tests, manual verification, and packaging complete successfully.
+
+Following these rules keeps operators aligned on what changed, when to upgrade, and how to recover if a release regresses critical workflows.


### PR DESCRIPTION
## Summary
- [x] Documented semantic versioning rules for toolkit manifests and changelog expectations.
- [x] Linked the new versioning guide from the authoring overview plus testing & release checklist.
- [x] Marked the `versioning-scheme` backlog item complete and refreshed Codex state/journal entries.

## Testing
- [ ] `backend` checks (`pytest`, formatters, or targeted unit tests). _Not run; documentation-only update._
- [ ] `frontend` checks (`npm test`, linting, or storybook if applicable). _Not run; documentation-only update._
- [ ] Other validation (docker-compose smoke test, manual scenario, etc.). _Not required for docs-only change._

## Documentation
- [ ] Updated operator docs under `frontend/documentation` if user journeys changed. _Not needed for this task._
- [x] Updated internal docs or the Codex state (`ai/ops/codex.md`, `docs/TODO.yaml`, `ai/state/*`) when workflows or priorities shifted.

## Deployment considerations
- [ ] Secrets, feature flags, or migrations require coordination and are documented in the PR description. _Not applicable._

------
https://chatgpt.com/codex/tasks/task_b_68dcad46daa88328855695869d292026