### PR TITLE
Feature/login throttle lockout

### DIFF
--- a/ai/state/journal.md
+++ b/ai/state/journal.md
@@ -47,6 +47,11 @@ Track Codex sessions chronologically. Each entry should capture what was attempt
 - Refreshed `.env.example`, the manual dev workflow, and the Docker Compose checklist so operators generate their own secrets before booting the stack (`.env.example`, `README.md`, `docs/project-setup.md`).
 - Rendered the compose config with the updated `.env` to confirm required variables behave as expected (`docker compose config`; `docker-compose.yml`).
 
+## 2025-10-01 Local login throttling kickoff
+- Promoted TODO `login-throttling` to in_progress and captured the Redis-backed lockout approach in the task notes (`docs/TODO.yaml:189`).
+- Introduced throttle helpers, provider wiring, and regression coverage for lockout, failure, and reset paths to guard the new behaviour (`backend/app/security/throttling.py`, `backend/app/security/providers/local.py`, `backend/tests/test_local_auth_provider.py`).
+- Documented the new configuration knobs and audit signals for operators managing the local provider (`docs/authentication/providers.md`).
+
 ## 2025-09-21 Postgres bootstrap validation
 - Closed TODO `remove-default-postgres-creds` by wiring a new env preflight into `bootstrap-stack.sh` that rejects placeholder Postgres credentials before Docker services launch (`backend/app/core/postgres_env.py`, `bootstrap-stack.sh`; Context: docs/TODO.yaml).
 - Added pytest coverage to lock the validator’s behaviour around placeholders, mismatched `DATABASE_URL` values, and minimum password length (`backend/tests/test_postgres_env.py`; Context: backend tests).
@@ -104,4 +109,3 @@ Track Codex sessions chronologically. Each entry should capture what was attempt
 - Added guards in `backend/app/services/auth.py` so refresh attempts missing `token_use` or `typ` are rejected with 401 responses prior to session lookups (Context: backend/app/services/auth.py:149).
 - Authored `backend/tests/test_auth_service.py` covering missing-claim failures and the updated happy path; `python -m pytest backend/tests/test_auth_service.py` currently fails in this environment because `fastapi` is unavailable, so follow-up runs need dependencies installed (Context: backend/tests/test_auth_service.py:1).
 - Promoted `decode_token` to a top-level import so the refresh guard stays patchable and reran `pytest backend/tests/test_auth_service.py`; run still needs FastAPI installed in this environment to complete.
-

--- a/ai/state/progress.json
+++ b/ai/state/progress.json
@@ -1,9 +1,9 @@
 {
   "version": 1,
-  "last_updated": "2025-10-01T05:35:02+00:00",
-  "session_counter": 19,
-  "active_task": null,
-  "last_task_id": "token-assertions",
+  "last_updated": "2025-10-01T06:20:00+00:00",
+  "session_counter": 20,
+  "active_task": "login-throttling",
+  "last_task_id": "login-throttling",
   "recent_updates": [
     {
       "task_id": "token-assertions",
@@ -97,5 +97,5 @@
     }
   ],
   "candidate_next_tasks": [],
-  "notes": "Initialised by Codex; update this file whenever focus or status changes. Architecture/schema references refreshed in session 2."
+  "notes": "Initialised by Codex; update this file whenever focus or status changes. Architecture/schema references refreshed in session 2. Local provider throttling and audit coverage underway; backend tests staged for lockout behaviour."
 }

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -30,6 +30,21 @@ class AuthProviderBase(BaseModel):
 class LocalAuthProvider(AuthProviderBase):
     type: Literal["local"] = "local"
     allow_registration: bool = False
+    max_attempts: int = Field(
+        default=5,
+        ge=0,
+        description="Maximum failed login attempts before the account is locked. Set to 0 to disable throttling.",
+    )
+    window_seconds: int = Field(
+        default=300,
+        ge=0,
+        description="Sliding window in seconds for counting failed attempts. Set to 0 to disable throttling.",
+    )
+    lockout_seconds: int = Field(
+        default=900,
+        ge=0,
+        description="Lockout duration in seconds once the failed attempt threshold is reached. Set to 0 to disable throttling.",
+    )
 
 
 class OidcAuthProvider(AuthProviderBase):

--- a/backend/app/security/audit_events.py
+++ b/backend/app/security/audit_events.py
@@ -25,6 +25,12 @@ AUDIT_EVENT_DEFINITIONS: Dict[str, AuditEventDefinition] = {
         description="Failed authentication attempt was rejected.",
         severity="warning",
     ),
+    "auth.login.lockout": AuditEventDefinition(
+        name="auth.login.lockout",
+        category="authentication",
+        description="Account temporarily locked after repeated failed authentication attempts.",
+        severity="warning",
+    ),
     "auth.logout": AuditEventDefinition(
         name="auth.logout",
         category="authentication",

--- a/backend/app/security/providers/local.py
+++ b/backend/app/security/providers/local.py
@@ -6,15 +6,21 @@ from fastapi import HTTPException, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ...config import LocalAuthProvider as LocalAuthConfig
+from ...core.redis import get_redis
 from ...models.user import User
 from ...services.audit import AuditService
 from ...services.users import UserService
 from ..passwords import verify_password
+from ..throttling import LoginThrottleConfig, check_lockout, record_failure, reset_attempts
 from .base import AuthProvider, AuthResult
 
 
 class LocalAuthProvider(AuthProvider):
     config_model = LocalAuthConfig
+
+    def _throttle_config(self) -> LoginThrottleConfig:
+        return LoginThrottleConfig.from_provider(self.config)
+
     async def begin(self, request: Request) -> Dict[str, Any]:
         # Local auth happens inline; nothing to begin.
         return {"type": "form"}
@@ -29,6 +35,30 @@ class LocalAuthProvider(AuthProvider):
         audit_service = AuditService(session)
         client_ip = request.client.host if request.client else None
         user_agent = request.headers.get("user-agent")
+
+        throttle_config = self._throttle_config()
+        redis_client = None
+        if throttle_config.enabled:
+            redis_client = get_redis()
+            lockout_ttl = check_lockout(redis_client, username)
+            if lockout_ttl > 0:
+                await audit_service.log(
+                    actor=None,
+                    event="auth.login.lockout",
+                    payload={
+                        "provider": self.name,
+                        "username": username,
+                        "reason": "lockout_active",
+                        "lockout_seconds": lockout_ttl,
+                    },
+                    source_ip=client_ip,
+                    user_agent=user_agent,
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                    detail="Account temporarily locked due to too many failed login attempts.",
+                )
+
         user: User | None = await user_service.get_by_username(username)
         if not user or not verify_password(password, user.password_hash):
             await audit_service.log(
@@ -39,6 +69,25 @@ class LocalAuthProvider(AuthProvider):
                 source_ip=client_ip,
                 user_agent=user_agent,
             )
+            if throttle_config.enabled and redis_client is not None:
+                locked, metric = record_failure(redis_client, username, throttle_config)
+                if locked:
+                    await audit_service.log(
+                        actor=user,
+                        event="auth.login.lockout",
+                        payload={
+                            "provider": self.name,
+                            "username": username,
+                            "reason": "lockout_threshold",
+                            "lockout_seconds": metric,
+                        },
+                        source_ip=client_ip,
+                        user_agent=user_agent,
+                    )
+                    raise HTTPException(
+                        status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                        detail="Account temporarily locked due to too many failed login attempts.",
+                    )
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid username or password")
         if not user.is_active:
             await audit_service.log(
@@ -49,9 +98,30 @@ class LocalAuthProvider(AuthProvider):
                 source_ip=client_ip,
                 user_agent=user_agent,
             )
+            if throttle_config.enabled and redis_client is not None:
+                locked, metric = record_failure(redis_client, username, throttle_config)
+                if locked:
+                    await audit_service.log(
+                        actor=user,
+                        event="auth.login.lockout",
+                        payload={
+                            "provider": self.name,
+                            "username": username,
+                            "reason": "lockout_threshold",
+                            "lockout_seconds": metric,
+                        },
+                        source_ip=client_ip,
+                        user_agent=user_agent,
+                    )
+                    raise HTTPException(
+                        status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                        detail="Account temporarily locked due to too many failed login attempts.",
+                    )
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="User disabled")
 
         await user_service.mark_login(user)
+        if throttle_config.enabled and redis_client is not None:
+            reset_attempts(redis_client, username)
         roles = [role.slug for role in user.roles] or self.default_roles
         return AuthResult(
             user_external_id=user.id,

--- a/backend/app/security/throttling.py
+++ b/backend/app/security/throttling.py
@@ -20,15 +20,20 @@ class LoginThrottleConfig:
         return all(value > 0 for value in (self.max_attempts, self.window_seconds, self.lockout_seconds))
 
     @classmethod
-    def from_provider(cls, provider_config: "LocalAuthProvider") -> "LoginThrottleConfig":
-        from ..config import LocalAuthProvider  # Local import to avoid circular dependency
+    def from_provider(cls, provider_config: object) -> "LoginThrottleConfig":
+        """Build config from a local auth provider definition.
 
-        if not isinstance(provider_config, LocalAuthProvider):
-            raise TypeError("provider_config must be an instance of LocalAuthProvider")
+        Accepts duck-typed objects (Pydantic models or dict-backed instances) so tests can
+        construct providers without importing the settings class directly.
+        """
+
+        max_attempts = getattr(provider_config, "max_attempts", 0)
+        window_seconds = getattr(provider_config, "window_seconds", 0)
+        lockout_seconds = getattr(provider_config, "lockout_seconds", 0)
         return cls(
-            max_attempts=provider_config.max_attempts,
-            window_seconds=provider_config.window_seconds,
-            lockout_seconds=provider_config.lockout_seconds,
+            max_attempts=int(max_attempts),
+            window_seconds=int(window_seconds),
+            lockout_seconds=int(lockout_seconds),
         )
 
 

--- a/backend/app/security/throttling.py
+++ b/backend/app/security/throttling.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from redis import Redis
+
+from ..core.redis import redis_key
+
+
+@dataclass(frozen=True)
+class LoginThrottleConfig:
+    """Holds throttle configuration for local authentication."""
+
+    max_attempts: int
+    window_seconds: int
+    lockout_seconds: int
+
+    @property
+    def enabled(self) -> bool:
+        return all(value > 0 for value in (self.max_attempts, self.window_seconds, self.lockout_seconds))
+
+    @classmethod
+    def from_provider(cls, provider_config: "LocalAuthProvider") -> "LoginThrottleConfig":
+        from ..config import LocalAuthProvider  # Local import to avoid circular dependency
+
+        if not isinstance(provider_config, LocalAuthProvider):
+            raise TypeError("provider_config must be an instance of LocalAuthProvider")
+        return cls(
+            max_attempts=provider_config.max_attempts,
+            window_seconds=provider_config.window_seconds,
+            lockout_seconds=provider_config.lockout_seconds,
+        )
+
+
+def _normalize_subject(subject: str) -> str:
+    return subject.strip().lower()
+
+
+def _attempt_key(subject: str) -> str:
+    return redis_key("auth", "local", "attempts", subject)
+
+
+def _lockout_key(subject: str) -> str:
+    return redis_key("auth", "local", "lockout", subject)
+
+
+def check_lockout(client: Redis, subject: str) -> int:
+    """Return lockout TTL (seconds) if the subject is locked, otherwise 0."""
+
+    normalized = _normalize_subject(subject)
+    ttl = client.ttl(_lockout_key(normalized))
+    if ttl and ttl > 0:
+        return ttl
+    return 0
+
+
+def record_failure(client: Redis, subject: str, config: LoginThrottleConfig) -> tuple[bool, int]:
+    """Record a failed login attempt.
+
+    Returns a tuple of (locked, metric) where metric is the remaining lockout TTL if locked,
+    otherwise the number of attempts remaining before lockout.
+    """
+
+    if not config.enabled:
+        return False, config.max_attempts
+
+    normalized = _normalize_subject(subject)
+    attempts_key = _attempt_key(normalized)
+    attempts = client.incr(attempts_key)
+    client.expire(attempts_key, config.window_seconds)
+
+    if attempts >= config.max_attempts:
+        client.delete(attempts_key)
+        lock_key = _lockout_key(normalized)
+        client.set(lock_key, "1", ex=config.lockout_seconds)
+        ttl = client.ttl(lock_key)
+        return True, ttl if ttl and ttl > 0 else config.lockout_seconds
+
+    remaining = max(config.max_attempts - attempts, 0)
+    return False, remaining
+
+
+def reset_attempts(client: Redis, subject: str) -> None:
+    """Clear stored failed-attempt counters for the subject."""
+
+    normalized = _normalize_subject(subject)
+    client.delete(_attempt_key(normalized))
+
+
+__all__ = [
+    "LoginThrottleConfig",
+    "check_lockout",
+    "record_failure",
+    "reset_attempts",
+]

--- a/backend/tests/test_local_auth_provider.py
+++ b/backend/tests/test_local_auth_provider.py
@@ -1,0 +1,128 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+from fastapi import HTTPException, status
+
+from app.config import LocalAuthProvider as LocalAuthConfig
+from app.security.providers.local import LocalAuthProvider
+
+
+class LocalAuthProviderThrottleTests(unittest.IsolatedAsyncioTestCase):
+    async def test_active_lockout_blocks_login(self) -> None:
+        provider = LocalAuthProvider(
+            LocalAuthConfig(name="local", max_attempts=5, window_seconds=60, lockout_seconds=300)
+        )
+        request = SimpleNamespace(
+            json=AsyncMock(return_value={"username": "alice", "password": "secret"}),
+            client=SimpleNamespace(host="198.51.100.10"),
+            headers={"user-agent": "pytest"},
+        )
+        session = AsyncMock()
+
+        with (
+            patch("app.security.providers.local.get_redis", return_value=Mock()) as mock_get_redis,
+            patch("app.security.providers.local.check_lockout", return_value=180),
+            patch("app.security.providers.local.UserService") as user_service_cls,
+            patch("app.security.providers.local.AuditService") as audit_service_cls,
+        ):
+            user_service = user_service_cls.return_value
+            user_service.get_by_username = AsyncMock()
+            audit_service = audit_service_cls.return_value
+            audit_service.log = AsyncMock()
+
+            with self.assertRaises(HTTPException) as exc:
+                await provider.complete(request, session)
+
+            self.assertEqual(exc.exception.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+            audit_calls = [call.kwargs["event"] for call in audit_service.log.await_args_list]
+            self.assertEqual(audit_calls, ["auth.login.lockout"])
+            user_service.get_by_username.assert_not_awaited()
+            mock_get_redis.assert_called_once()
+
+    async def test_failed_login_triggers_lockout(self) -> None:
+        provider = LocalAuthProvider(
+            LocalAuthConfig(name="local", max_attempts=3, window_seconds=120, lockout_seconds=600)
+        )
+        user = SimpleNamespace(
+            id="user-1",
+            username="alice",
+            email="alice@example.com",
+            display_name="Alice",
+            roles=[SimpleNamespace(slug="toolkit.user")],
+            password_hash="hashed",
+            is_active=True,
+        )
+        request = SimpleNamespace(
+            json=AsyncMock(return_value={"username": "alice", "password": "bad"}),
+            client=SimpleNamespace(host="203.0.113.15"),
+            headers={"user-agent": "pytest"},
+        )
+        session = AsyncMock()
+
+        with (
+            patch("app.security.providers.local.get_redis", return_value=Mock()) as mock_get_redis,
+            patch("app.security.providers.local.check_lockout", return_value=0),
+            patch("app.security.providers.local.record_failure", return_value=(True, 500)) as record_failure,
+            patch("app.security.providers.local.verify_password", return_value=False),
+            patch("app.security.providers.local.UserService") as user_service_cls,
+            patch("app.security.providers.local.AuditService") as audit_service_cls,
+        ):
+            user_service = user_service_cls.return_value
+            user_service.get_by_username = AsyncMock(return_value=user)
+            audit_service = audit_service_cls.return_value
+            audit_service.log = AsyncMock()
+
+            with self.assertRaises(HTTPException) as exc:
+                await provider.complete(request, session)
+
+            self.assertEqual(exc.exception.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+            events = [call.kwargs["event"] for call in audit_service.log.await_args_list]
+            self.assertIn("auth.login.failure", events)
+            self.assertIn("auth.login.lockout", events)
+            record_failure.assert_called_once_with(mock_get_redis.return_value, "alice", provider._throttle_config())
+
+    async def test_success_resets_attempt_counter(self) -> None:
+        provider = LocalAuthProvider(
+            LocalAuthConfig(name="local", max_attempts=3, window_seconds=120, lockout_seconds=600)
+        )
+        user = SimpleNamespace(
+            id="user-1",
+            username="alice",
+            email="alice@example.com",
+            display_name="Alice",
+            roles=[SimpleNamespace(slug="toolkit.user")],
+            password_hash="hashed",
+            is_active=True,
+        )
+        request = SimpleNamespace(
+            json=AsyncMock(return_value={"username": "alice", "password": "good"}),
+            client=SimpleNamespace(host="198.51.100.7"),
+            headers={"user-agent": "pytest"},
+        )
+        session = AsyncMock()
+
+        with (
+            patch("app.security.providers.local.get_redis", return_value=Mock()) as mock_get_redis,
+            patch("app.security.providers.local.check_lockout", return_value=0),
+            patch("app.security.providers.local.record_failure") as record_failure,
+            patch("app.security.providers.local.reset_attempts") as reset_attempts,
+            patch("app.security.providers.local.verify_password", return_value=True),
+            patch("app.security.providers.local.UserService") as user_service_cls,
+            patch("app.security.providers.local.AuditService") as audit_service_cls,
+        ):
+            user_service = user_service_cls.return_value
+            user_service.get_by_username = AsyncMock(return_value=user)
+            user_service.mark_login = AsyncMock()
+            audit_service = audit_service_cls.return_value
+            audit_service.log = AsyncMock()
+
+            result = await provider.complete(request, session)
+
+            self.assertEqual(result.username, "alice")
+            reset_attempts.assert_called_once_with(mock_get_redis.return_value, "alice")
+            record_failure.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/TODO.yaml
+++ b/docs/TODO.yaml
@@ -188,8 +188,11 @@ areas:
           - "2025-10-01: Promoted decode_token to module scope, refreshed AuthService guard, and added async tests verifying failure and success paths."
       - id: login-throttling
         title: Implement login throttling / lockout for the local provider and emit audit logs.
-        status: backlog
+        status: in_progress
         priority: medium
+        notes:
+          - "Emit audit metadata whenever throttle or lockout conditions trigger so operators can review attempts."
+          - "2025-10-01: Adding Redis-backed throttle defaults, audit coverage, and local documentation for lockout behaviour."
       - id: browser-storage-hardening
         title: Keep access tokens out of localStorage; rely on httpOnly refresh cookies or in-memory storage.
         status: backlog

--- a/docs/authentication/providers.md
+++ b/docs/authentication/providers.md
@@ -114,6 +114,16 @@ The UI exposes a **Load metadata** button in the OIDC form—paste the discovery
 4. **TLS considerations** – prefer LDAPS. If the directory uses a private CA, add the certificate bundle to the container and reference it via `REQUESTS_CA_BUNDLE` or system trust store. Vault itself can use `VAULT_CA_CERT` for custom roots.
 5. **Test connectivity** from **Administration → Toolbox settings → Auth → Test connection** after saving changes.
 
+## Local Provider Throttling
+
+The built-in local authentication provider now enforces rate limiting to slow brute-force attempts. Each provider definition accepts three optional fields:
+
+- `max_attempts` – failed-login budget inside the sliding window (default `5`).
+- `window_seconds` – how long, in seconds, to keep counting those failures (default `300`).
+- `lockout_seconds` – lockout duration once the budget is exceeded (default `900`).
+
+Set these values from **Administration → Toolbox settings → Auth** or via the JSON configuration hooks (`AUTH_PROVIDERS_JSON`, `AUTH_PROVIDERS_FILE`). Setting any field to `0` disables throttling for that provider. When the limit is reached the API returns HTTP `429` and records an `auth.login.lockout` audit event alongside the existing `auth.login.failure` entries so operators can trace repeated abuse. Successful logins clear the failure counter.
+
 ## Operational Checklist
 
 - [ ] Vault initialised, unsealed, and reachable at `VAULT_ADDR`.


### PR DESCRIPTION
## Summary
- add throttle configuration and auditing for the local auth provider
- implement a redis-backed helper that enforces lockouts and clears counters on success
- document the new knobs and cover lockout paths with targeted backend tests

## Testing
- pytest backend/tests/test_local_auth_provider.py *(fails: ModuleNotFoundError: fastapi)*

